### PR TITLE
UI to support selecting user role/type when signing up

### DIFF
--- a/android/app/.classpath
+++ b/android/app/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
+	<classpathentry kind="output" path="bin/default"/>
+</classpath>

--- a/android/app/.project
+++ b/android/app/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>app</name>
+	<comment>Project app created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/android/app/.settings/org.eclipse.buildship.core.prefs
+++ b/android/app/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,2 @@
+connection.project.dir=..
+eclipse.preferences.version=1

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.bnbsy.supplyside"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,90 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def parse_KV_file(file, separator='=')
+  file_abs_path = File.expand_path(file)
+  if !File.exists? file_abs_path
+    return [];
+  end
+  generated_key_values = {}
+  skip_line_start_symbols = ["#", "/"]
+  File.foreach(file_abs_path) do |line|
+    next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
+    plugin = line.split(pattern=separator)
+    if plugin.length == 2
+      podname = plugin[0].strip()
+      path = plugin[1].strip()
+      podpath = File.expand_path("#{path}", file_abs_path)
+      generated_key_values[podname] = podpath
+    else
+      puts "Invalid plugin specification: #{line}"
+    end
+  end
+  generated_key_values
+end
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  # Flutter Pod
+
+  copied_flutter_dir = File.join(__dir__, 'Flutter')
+  copied_framework_path = File.join(copied_flutter_dir, 'Flutter.framework')
+  copied_podspec_path = File.join(copied_flutter_dir, 'Flutter.podspec')
+  unless File.exist?(copied_framework_path) && File.exist?(copied_podspec_path)
+    # Copy Flutter.framework and Flutter.podspec to Flutter/ to have something to link against if the xcode backend script has not run yet.
+    # That script will copy the correct debug/profile/release version of the framework based on the currently selected Xcode configuration.
+    # CocoaPods will not embed the framework on pod install (before any build phases can generate) if the dylib does not exist.
+
+    generated_xcode_build_settings_path = File.join(copied_flutter_dir, 'Generated.xcconfig')
+    unless File.exist?(generated_xcode_build_settings_path)
+      raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+    end
+    generated_xcode_build_settings = parse_KV_file(generated_xcode_build_settings_path)
+    cached_framework_dir = generated_xcode_build_settings['FLUTTER_FRAMEWORK_DIR'];
+
+    unless File.exist?(copied_framework_path)
+      FileUtils.cp_r(File.join(cached_framework_dir, 'Flutter.framework'), copied_flutter_dir)
+    end
+    unless File.exist?(copied_podspec_path)
+      FileUtils.cp(File.join(cached_framework_dir, 'Flutter.podspec'), copied_flutter_dir)
+    end
+  end
+
+  # Keep pod path relative so it can be checked into Podfile.lock.
+  pod 'Flutter', :path => 'Flutter'
+
+  # Plugin Pods
+
+  # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
+  # referring to absolute paths on developers' machines.
+  system('rm -rf .symlinks')
+  system('mkdir -p .symlinks/plugins')
+  plugin_pods = parse_KV_file('../.flutter-plugins')
+  plugin_pods.each do |name, path|
+    symlink = File.join('.symlinks', 'plugins', name)
+    File.symlink(path, symlink)
+    pod name, :path => File.join(symlink, 'ios')
+  end
+end
+
+# Prevent Cocoapods from embedding a second Flutter framework and causing an error with the new Xcode build system.
+install! 'cocoapods', :disable_input_output_paths => true
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['ENABLE_BITCODE'] = 'NO'
+    end
+  end
+end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,170 @@
+PODS:
+  - Firebase/Auth (6.22.0):
+    - Firebase/CoreOnly
+    - FirebaseAuth (~> 6.5.1)
+  - Firebase/Core (6.22.0):
+    - Firebase/CoreOnly
+    - FirebaseAnalytics (= 6.4.1)
+  - Firebase/CoreOnly (6.22.0):
+    - FirebaseCore (= 6.6.6)
+  - Firebase/Database (6.22.0):
+    - Firebase/CoreOnly
+    - FirebaseDatabase (~> 6.1.4)
+  - firebase_auth (0.0.1):
+    - Firebase/Auth (~> 6.3)
+    - Firebase/Core
+    - Flutter
+  - firebase_auth_web (0.1.0):
+    - Flutter
+  - firebase_core (0.0.1):
+    - Firebase/Core
+    - Flutter
+  - firebase_core_web (0.1.0):
+    - Flutter
+  - firebase_database (0.0.1):
+    - Firebase/Database
+    - Flutter
+  - FirebaseAnalytics (6.4.1):
+    - FirebaseCore (~> 6.6)
+    - FirebaseInstallations (~> 1.1)
+    - GoogleAppMeasurement (= 6.4.1)
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
+    - GoogleUtilities/MethodSwizzler (~> 6.0)
+    - GoogleUtilities/Network (~> 6.0)
+    - "GoogleUtilities/NSData+zlib (~> 6.0)"
+    - nanopb (= 0.3.9011)
+  - FirebaseAuth (6.5.1):
+    - FirebaseAuthInterop (~> 1.0)
+    - FirebaseCore (~> 6.6)
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.5)
+    - GoogleUtilities/Environment (~> 6.5)
+    - GTMSessionFetcher/Core (~> 1.1)
+  - FirebaseAuthInterop (1.1.0)
+  - FirebaseCore (6.6.6):
+    - FirebaseCoreDiagnostics (~> 1.2)
+    - FirebaseCoreDiagnosticsInterop (~> 1.2)
+    - GoogleUtilities/Environment (~> 6.5)
+    - GoogleUtilities/Logger (~> 6.5)
+  - FirebaseCoreDiagnostics (1.2.3):
+    - FirebaseCoreDiagnosticsInterop (~> 1.2)
+    - GoogleDataTransportCCTSupport (~> 2.0)
+    - GoogleUtilities/Environment (~> 6.5)
+    - GoogleUtilities/Logger (~> 6.5)
+    - nanopb (~> 0.3.901)
+  - FirebaseCoreDiagnosticsInterop (1.2.0)
+  - FirebaseDatabase (6.1.4):
+    - FirebaseAuthInterop (~> 1.0)
+    - FirebaseCore (~> 6.0)
+    - leveldb-library (~> 1.22)
+  - FirebaseInstallations (1.1.1):
+    - FirebaseCore (~> 6.6)
+    - GoogleUtilities/UserDefaults (~> 6.5)
+    - PromisesObjC (~> 1.2)
+  - Flutter (1.0.0)
+  - GoogleAppMeasurement (6.4.1):
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
+    - GoogleUtilities/MethodSwizzler (~> 6.0)
+    - GoogleUtilities/Network (~> 6.0)
+    - "GoogleUtilities/NSData+zlib (~> 6.0)"
+    - nanopb (= 0.3.9011)
+  - GoogleDataTransport (5.1.1)
+  - GoogleDataTransportCCTSupport (2.0.2):
+    - GoogleDataTransport (~> 5.1)
+    - nanopb (~> 0.3.901)
+  - GoogleUtilities/AppDelegateSwizzler (6.5.2):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
+  - GoogleUtilities/Environment (6.5.2)
+  - GoogleUtilities/Logger (6.5.2):
+    - GoogleUtilities/Environment
+  - GoogleUtilities/MethodSwizzler (6.5.2):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/Network (6.5.2):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Reachability
+  - "GoogleUtilities/NSData+zlib (6.5.2)"
+  - GoogleUtilities/Reachability (6.5.2):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/UserDefaults (6.5.2):
+    - GoogleUtilities/Logger
+  - GTMSessionFetcher/Core (1.3.1)
+  - leveldb-library (1.22)
+  - nanopb (0.3.9011):
+    - nanopb/decode (= 0.3.9011)
+    - nanopb/encode (= 0.3.9011)
+  - nanopb/decode (0.3.9011)
+  - nanopb/encode (0.3.9011)
+  - PromisesObjC (1.2.8)
+
+DEPENDENCIES:
+  - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
+  - firebase_auth_web (from `.symlinks/plugins/firebase_auth_web/ios`)
+  - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
+  - firebase_core_web (from `.symlinks/plugins/firebase_core_web/ios`)
+  - firebase_database (from `.symlinks/plugins/firebase_database/ios`)
+  - Flutter (from `Flutter`)
+
+SPEC REPOS:
+  trunk:
+    - Firebase
+    - FirebaseAnalytics
+    - FirebaseAuth
+    - FirebaseAuthInterop
+    - FirebaseCore
+    - FirebaseCoreDiagnostics
+    - FirebaseCoreDiagnosticsInterop
+    - FirebaseDatabase
+    - FirebaseInstallations
+    - GoogleAppMeasurement
+    - GoogleDataTransport
+    - GoogleDataTransportCCTSupport
+    - GoogleUtilities
+    - GTMSessionFetcher
+    - leveldb-library
+    - nanopb
+    - PromisesObjC
+
+EXTERNAL SOURCES:
+  firebase_auth:
+    :path: ".symlinks/plugins/firebase_auth/ios"
+  firebase_auth_web:
+    :path: ".symlinks/plugins/firebase_auth_web/ios"
+  firebase_core:
+    :path: ".symlinks/plugins/firebase_core/ios"
+  firebase_core_web:
+    :path: ".symlinks/plugins/firebase_core_web/ios"
+  firebase_database:
+    :path: ".symlinks/plugins/firebase_database/ios"
+  Flutter:
+    :path: Flutter
+
+SPEC CHECKSUMS:
+  Firebase: 32f9520684e87c7af3f0704f7f88042626d6b536
+  firebase_auth: 4ee3a54d3f09434c508c284a62f895a741a30637
+  firebase_auth_web: 0955c07bcc06e84af76b9d4e32e6f31518f2d7de
+  firebase_core: 0d8be0e0d14c4902953aeb5ac5d7316d1fe4b978
+  firebase_core_web: d501d8b946b60c8af265428ce483b0fff5ad52d1
+  firebase_database: 8724d18445b3f77073e71237ca2048261e9d588f
+  FirebaseAnalytics: 83f822fd0d33a46f49f89b8c3ab16ab4d89df08a
+  FirebaseAuth: a6da11d78dfd956b7f7af3222a0f0b1c93ef8fc9
+  FirebaseAuthInterop: a0f37ae05833af156e72028f648d313f7e7592e9
+  FirebaseCore: 9aca0f1fffb405176ba15311a5621fcde4106fcf
+  FirebaseCoreDiagnostics: 13a6564cd6d5375066bbc8940cc1753af24497f3
+  FirebaseCoreDiagnosticsInterop: 296e2c5f5314500a850ad0b83e9e7c10b011a850
+  FirebaseDatabase: 0144e0706a4761f1b0e8679572eba8095ddb59be
+  FirebaseInstallations: acb3216eb9784d3b1d2d2d635ff74fa892cc0c44
+  Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
+  GoogleAppMeasurement: e49be3954045b17d046f271b9cc1ec052bad9702
+  GoogleDataTransport: 6ffa4dd0b6d547f8d27b91bd92fa9e197a3f5f1f
+  GoogleDataTransportCCTSupport: 12f02e5c8f09c055615de90bcd5ba2c375546051
+  GoogleUtilities: ad0f3b691c67909d03a3327cc205222ab8f42e0e
+  GTMSessionFetcher: cea130bbfe5a7edc8d06d3f0d17288c32ffe9925
+  leveldb-library: 55d93ee664b4007aac644a782d11da33fba316f7
+  nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
+  PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
+
+PODFILE CHECKSUM: 083258d7f5e80b42ea9bfee905fe93049bc04c64
+
+COCOAPODS: 1.9.1

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		BACBE7D1380CE1F883806375 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AB61F08D54C6BFE4D894DFD /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -35,12 +36,14 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		090F09D7027FCF77ABC7329D /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		766F38BC949F7B9EA5B41D3B /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -50,6 +53,8 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9AB61F08D54C6BFE4D894DFD /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C165D61FACDB0321AC48959C /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,12 +64,21 @@
 			files = (
 				9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */,
 				3B80C3941E831B6300D905FE /* App.framework in Frameworks */,
+				BACBE7D1380CE1F883806375 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		7E4F7416F3435D2BA7D6E466 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				9AB61F08D54C6BFE4D894DFD /* Pods_Runner.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
@@ -84,6 +98,8 @@
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
+				C9E5D6E7189B0A35819C26C5 /* Pods */,
+				7E4F7416F3435D2BA7D6E466 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -118,6 +134,17 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		C9E5D6E7189B0A35819C26C5 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				766F38BC949F7B9EA5B41D3B /* Pods-Runner.debug.xcconfig */,
+				090F09D7027FCF77ABC7329D /* Pods-Runner.release.xcconfig */,
+				C165D61FACDB0321AC48959C /* Pods-Runner.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -125,12 +152,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				B463B287B60138A9D35E021E /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				88BC84E82FE5FA3848AC04A8 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -203,6 +232,21 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" thin";
 		};
+		88BC84E82FE5FA3848AC04A8 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -216,6 +260,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		B463B287B60138A9D35E021E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Flutter
+import Firebase
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
@@ -7,6 +8,7 @@ import Flutter
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    FirebaseApp.configure()
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/ios/Runner/GoogleService-Info.plist
+++ b/ios/Runner/GoogleService-Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>226984467738-9ej1njvig7vt66koj6rvcfd93anmsuu0.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.226984467738-9ej1njvig7vt66koj6rvcfd93anmsuu0</string>
+	<key>API_KEY</key>
+	<string>AIzaSyDWqGVey4erE8hO5W2EmDAdbL2SRFsxr3w</string>
+	<key>GCM_SENDER_ID</key>
+	<string>226984467738</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.bnbsy.supplyside</string>
+	<key>PROJECT_ID</key>
+	<string>bay-shield</string>
+	<key>STORAGE_BUCKET</key>
+	<string>bay-shield.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:226984467738:ios:fc29fd48b5e04182d660a3</string>
+	<key>DATABASE_URL</key>
+	<string>https://bay-shield.firebaseio.com</string>
+</dict>
+</plist>

--- a/lib/datamodels/user.dart
+++ b/lib/datamodels/user.dart
@@ -4,17 +4,38 @@ import 'package:flutter/cupertino.dart';
 
 class User {
 
+  String id;
   String email;
-  int phoneNumber;
-  User(this.email, this.phoneNumber);
-  User.named({this.email, this.phoneNumber});
+  String type;
+  User({this.id, this.email, this.type});
 
+  User.fromData(Map<String, dynamic> data)
+    : id = data['id'],
+      email = data['email'],
+      type = data['type'] ?? '';
+      
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'email': email,
+      'type': type,
+    };
+  }
+
+  String getType() {
+    return this.type;
+  }
+ 
 }
 
 class MedicalFacility extends User {
 
-  MedicalFacility({String email, int phoneNumber, this.address, @required this.orgName, this.staffSize}) :
-    super(email, phoneNumber);
+  MedicalFacility({String id, String email, int phoneNumber, this.address, @required this.orgName, this.staffSize}) :
+    super(
+      id: id, 
+      email: email, 
+      type: "Medical Facility"
+    );
 
   String address;
   String orgName;

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -1,0 +1,8 @@
+import 'package:get_it/get_it.dart';
+import 'package:supplyside/util/firestore_users.dart';
+
+GetIt locator = GetIt.instance;
+
+void setupLocator() {
+  locator.registerLazySingleton(() => FirestoreUsers());
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,11 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:supplyside/screens/consumer_request_screen.dart';
 import 'package:supplyside/screens/login_screen.dart';
 import 'package:supplyside/theme.dart';
+import 'package:supplyside/locator.dart';
 import 'package:supplyside/util/consts.dart';
 import 'package:supplyside/util/authentication.dart';
 import 'package:supplyside/screens/root_screen.dart';
 
-void main() => runApp(MyApp());
+void main(){
+  setupLocator();
+  runApp(MyApp());
+} 
 
 class MyApp extends StatelessWidget {
   // This widget is the root of your application.

--- a/lib/screens/hub_screen.dart
+++ b/lib/screens/hub_screen.dart
@@ -2,20 +2,20 @@ import 'package:flutter/material.dart';
 import 'package:supplyside/util/authentication.dart';
 import 'package:firebase_database/firebase_database.dart';
 
-class MakerScreen extends StatefulWidget {
+class HubScreen extends StatefulWidget {
 
-  MakerScreen({Key key, this.auth, this.userId, this.logoutCallback}) : super(key: key);
+  HubScreen({Key key, this.auth, this.userId, this.logoutCallback}) : super(key: key);
 
   final BaseAuth auth;
   final VoidCallback logoutCallback;
   final String userId;
 
   @override
-  State<StatefulWidget> createState() => new _MakerScreenState();
+  State<StatefulWidget> createState() => new _HubScreenState();
 
 }
 
-class _MakerScreenState extends State<MakerScreen>{
+class _HubScreenState extends State<HubScreen>{
 
   signOut() async {
     try {
@@ -30,7 +30,7 @@ class _MakerScreenState extends State<MakerScreen>{
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: new AppBar(
-        title: new Text("Maker Home"),
+        title: new Text("Collection Hub Home"),
         backgroundColor: Color(0xFF313F84),
         actions: <Widget>[
             new FlatButton(

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supplyside/util/authentication.dart';
+import 'package:supplyside/screens/user_type_screen.dart';
 
 class LoginSignupScreen extends StatefulWidget {
   LoginSignupScreen({this.auth, this.loginCallback});
@@ -32,6 +33,16 @@ class _LoginSignupScreenState extends State<LoginSignupScreen>{
     return false;
   }
 
+  // Go to user type screen when succesfully signed up
+  Future navigateToUserType(context, String userId) async {
+    Navigator.push(context, MaterialPageRoute(builder: (context) => UserTypeScreen(userId: userId,
+            auth: widget.auth,
+            loginCallback: widget.loginCallback,
+            )
+            ))
+          ;
+  }
+
   // Perform login or signup
   void validateAndSubmit() async {
     setState(() {
@@ -47,12 +58,14 @@ class _LoginSignupScreenState extends State<LoginSignupScreen>{
         } else {
           userId = await widget.auth.signUp(_email, _password);
           print('Signed up user: $userId');
+          await widget.auth.signIn(_email, _password);
+          navigateToUserType(context, userId);
         }
         setState(() {
           _isLoading = false;
         });
 
-        if (userId.length > 0 && userId != null && _isLoginForm) {
+        if (userId.length > 0 && userId != null) {
           widget.loginCallback();
         }
       } catch (e) {
@@ -91,7 +104,7 @@ class _LoginSignupScreenState extends State<LoginSignupScreen>{
   Widget build(BuildContext context) {
     return new Scaffold(
         appBar: new AppBar(
-          title: new Text('BayShield Medical Facility Login'),
+          title: new Text('BayShield Login'),
           backgroundColor: Color(0xFF313F84),
         ),
         body: Stack(

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:supplyside/util/authentication.dart';
 import 'package:supplyside/screens/user_type_screen.dart';
+import 'package:supplyside/util/firestore_users.dart';
+import 'package:supplyside/datamodels/user.dart';
+import 'package:supplyside/locator.dart';
 
 class LoginSignupScreen extends StatefulWidget {
   LoginSignupScreen({this.auth, this.loginCallback});
@@ -15,6 +18,7 @@ class LoginSignupScreen extends StatefulWidget {
 
 class _LoginSignupScreenState extends State<LoginSignupScreen>{
   final _formKey = new GlobalKey<FormState>();
+  final FirestoreUsers _firestoreUsers = locator<FirestoreUsers>();
 
   String _email;
   String _password;
@@ -35,12 +39,14 @@ class _LoginSignupScreenState extends State<LoginSignupScreen>{
 
   // Go to user type screen when succesfully signed up
   Future navigateToUserType(context, String userId) async {
-    Navigator.push(context, MaterialPageRoute(builder: (context) => UserTypeScreen(userId: userId,
-            auth: widget.auth,
-            loginCallback: widget.loginCallback,
-            )
-            ))
-          ;
+    if (userId.length > 0 && userId != null) {
+      widget.loginCallback();
+    }
+    Navigator.pushReplacement(context, MaterialPageRoute(builder: (context) => UserTypeScreen(userId: userId,
+      auth: widget.auth,
+      )
+      ))
+    ;
   }
 
   // Perform login or signup
@@ -56,9 +62,11 @@ class _LoginSignupScreenState extends State<LoginSignupScreen>{
           userId = await widget.auth.signIn(_email, _password);
           print('Signed in: $userId');
         } else {
+          // Sign up process
           userId = await widget.auth.signUp(_email, _password);
           print('Signed up user: $userId');
           await widget.auth.signIn(_email, _password);
+          await _firestoreUsers.createUser(User(id: userId, email: _email, type: ""));
           navigateToUserType(context, userId);
         }
         setState(() {

--- a/lib/screens/root_screen.dart
+++ b/lib/screens/root_screen.dart
@@ -75,7 +75,7 @@ class _RootScreenState extends State<RootScreen> {
           loginCallback: loginCallback,
         );
         break;
-      case AuthStatus.LOGGED_IN:
+      case AuthStatus.LOGGED_IN: // TODO: redirect to different screens depending on user role
         if (_userId.length > 0 && _userId != null) {
           return new ConsumerScreen(
             userId: _userId,

--- a/lib/screens/root_screen.dart
+++ b/lib/screens/root_screen.dart
@@ -2,6 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:supplyside/screens/login_screen.dart';
 import 'package:supplyside/util/authentication.dart';
 import 'package:supplyside/screens/consumer_screen.dart';
+import 'package:supplyside/screens/maker_screen.dart';
+import 'package:supplyside/screens/hub_screen.dart';
+import 'package:supplyside/util/firestore_users.dart';
+import 'package:supplyside/datamodels/user.dart';
+import 'package:supplyside/locator.dart';
 
 enum AuthStatus {
   NOT_DETERMINED,
@@ -19,8 +24,11 @@ class RootScreen extends StatefulWidget {
 }
 
 class _RootScreenState extends State<RootScreen> {
+  final FirestoreUsers _firestoreUsers = locator<FirestoreUsers>();
   AuthStatus authStatus = AuthStatus.NOT_DETERMINED;
   String _userId = "";
+  User user;
+  String _userType = "";
 
   @override
   void initState() {
@@ -51,7 +59,23 @@ class _RootScreenState extends State<RootScreen> {
     setState(() {
       authStatus = AuthStatus.NOT_LOGGED_IN;
       _userId = "";
+      user = null;
+      _userType = '';
     });
+  }
+
+  Future _getUserType(String id) async {
+    try {
+      User temp = await _firestoreUsers.getUser(_userId);
+      if (temp != null) {
+        setState(() {
+          user = temp;
+          _userType = temp.getType();
+        });
+      }     
+    } catch (e) {
+      return e.message;
+    }      
   }
 
   Widget buildWaitingScreen() {
@@ -75,13 +99,39 @@ class _RootScreenState extends State<RootScreen> {
           loginCallback: loginCallback,
         );
         break;
-      case AuthStatus.LOGGED_IN: // TODO: redirect to different screens depending on user role
+      case AuthStatus.LOGGED_IN: 
+         _getUserType(_userId);
         if (_userId.length > 0 && _userId != null) {
-          return new ConsumerScreen(
-            userId: _userId,
-            auth: widget.auth,
-            logoutCallback: logoutCallback,
-          );
+          switch(_userType) { 
+              case 'Medical Facility': { 
+                return new ConsumerScreen(
+                  userId: _userId,
+                  auth: widget.auth,
+                  logoutCallback: logoutCallback,
+                );
+              } 
+              break; 
+              case 'Maker': { 
+                return new MakerScreen(
+                userId: _userId,
+                auth: widget.auth,
+                logoutCallback: logoutCallback,
+                );
+              } 
+              break; 
+              case 'Collection Hub': { 
+                return new HubScreen(
+                userId: _userId,
+                auth: widget.auth,
+                logoutCallback: logoutCallback,
+                );
+              } 
+              break;      
+              default: { 
+                return buildWaitingScreen();
+              }
+              break; 
+            } 
         } else
           return buildWaitingScreen();
         break;

--- a/lib/screens/user_type_screen.dart
+++ b/lib/screens/user_type_screen.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:supplyside/util/authentication.dart';
 import 'package:supplyside/screens/root_screen.dart';
+import 'package:supplyside/util/firestore_users.dart';
+import 'package:supplyside/locator.dart';
 
 class UserTypeScreen extends StatefulWidget {
-  UserTypeScreen({this.userId, this.auth, this.loginCallback});
+  UserTypeScreen({this.userId, this.auth});
 
   final BaseAuth auth;
   final String userId;
-  final VoidCallback loginCallback;
 
   @override
   State<StatefulWidget> createState() => new _UserTypeScreenState();
@@ -15,6 +16,15 @@ class UserTypeScreen extends StatefulWidget {
 }
 
 class _UserTypeScreenState extends State<UserTypeScreen>{
+  final FirestoreUsers _firestoreUsers = locator<FirestoreUsers>();
+
+  Future updateUserType(String userId, String type) async {
+    try {
+      await _firestoreUsers.updateUserType(userId, type);
+    } catch (e) {
+      return e.message;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -50,8 +60,8 @@ class _UserTypeScreenState extends State<UserTypeScreen>{
             child: new Text(label,
                 style: new TextStyle(fontSize: 20.0, color: Colors.white)),
             onPressed: () {
-              widget.loginCallback();
-              Navigator.push(
+              updateUserType(widget.userId, label);
+              Navigator.pushReplacement(
                 context,
                 MaterialPageRoute(builder: (context) => RootScreen(auth: widget.auth)),
               );

--- a/lib/screens/user_type_screen.dart
+++ b/lib/screens/user_type_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:supplyside/util/authentication.dart';
+import 'package:supplyside/screens/root_screen.dart';
+
+class UserTypeScreen extends StatefulWidget {
+  UserTypeScreen({this.userId, this.auth, this.loginCallback});
+
+  final BaseAuth auth;
+  final String userId;
+  final VoidCallback loginCallback;
+
+  @override
+  State<StatefulWidget> createState() => new _UserTypeScreenState();
+
+}
+
+class _UserTypeScreenState extends State<UserTypeScreen>{
+
+  @override
+  Widget build(BuildContext context) {
+
+    Widget promptSection = Container(
+      padding: const EdgeInsets.all(32),
+      child: Text(
+        'Sign Up as a...',
+        textAlign: TextAlign.center,
+        softWrap: true,
+        style: TextStyle(
+          fontSize: 20.0,
+          fontWeight: FontWeight.w400,
+        ),
+      ),
+    );
+
+  Column _buildButtonColumn(IconData icon, String label) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(icon, color: Color(0xFFE6B819), size: 32.0,),
+        Container(
+          margin: const EdgeInsets.only(top: 16, bottom: 32),
+          child: SizedBox(
+          height: 40.0,
+          child: new RaisedButton(
+            elevation: 5.0,
+            shape: new RoundedRectangleBorder(
+                borderRadius: new BorderRadius.circular(30.0)),
+            color: Color(0xFF313F84),
+            child: new Text(label,
+                style: new TextStyle(fontSize: 20.0, color: Colors.white)),
+            onPressed: () {
+              widget.loginCallback();
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => RootScreen(auth: widget.auth)),
+              );
+            }
+          ),
+        ))
+      ],
+    );
+  }
+
+  Widget buttonSection = Container(
+    margin: const EdgeInsets.only(top: 32),
+    child: Column(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        _buildButtonColumn(Icons.local_hospital, 'Medical Facility'),
+        _buildButtonColumn(Icons.share, 'Collection Hub'),
+        _buildButtonColumn(Icons.lightbulb_outline, 'Maker'),
+      ],
+    ),
+  );
+
+    return new Scaffold(
+      appBar: new AppBar(
+          title: new Text('BayShield Signup'),
+          backgroundColor: Color(0xFF313F84),
+        ),
+      body: ListView(
+        children: [promptSection, buttonSection],
+      ),
+    );
+  }
+}

--- a/lib/util/firestore_users.dart
+++ b/lib/util/firestore_users.dart
@@ -1,0 +1,35 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:supplyside/datamodels/user.dart';
+
+class FirestoreUsers {
+  final CollectionReference _usersCollectionReference =
+      Firestore.instance.collection("users");
+
+  Future createUser(User user) async {
+    try {
+      await _usersCollectionReference.document(user.id).setData(user.toJson());
+      print('Saved to database: $user.email');
+    } catch (e) {
+      return e.message;
+    }
+  }
+
+  Future getUser(String id) async {
+    try {
+      var userData = await _usersCollectionReference.document(id).get();
+      return User.fromData(userData.data);
+    } catch (e) {
+      print(e.message);
+      return null;
+    }
+  }
+
+  Future updateUserType(String id, String type) async {
+    try {
+      await _usersCollectionReference.document(id).updateData({"type": type});
+      print('Saved type: $type');
+    } catch (e) {
+      return e.message;
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -36,6 +36,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.2"
+  cloud_firestore:
+    dependency: "direct main"
+    description:
+      name: cloud_firestore
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.5"
+  cloud_firestore_platform_interface:
+    dependency: transitive
+    description:
+      name: cloud_firestore_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
+  cloud_firestore_web:
+    dependency: transitive
+    description:
+      name: cloud_firestore_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1+2"
   collection:
     dependency: transitive
     description:
@@ -135,6 +156,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  get_it:
+    dependency: "direct main"
+    description:
+      name: get_it
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.1"
   http:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,8 @@ dependencies:
   cupertino_icons: ^0.1.2
   firebase_auth: ^0.15.5+3
   firebase_database: ^3.1.3
+  cloud_firestore: ^0.13.5
+  get_it: ^4.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### (new commit)

### Demo
![c19bayshield_userdb](https://user-images.githubusercontent.com/25168261/79397129-3acfa300-7f32-11ea-89ac-ee824c6be47f.gif)

### Edited .dart files:
`login_screen`: create new document in users collection upon valid signup
`maker_screen`: basic stateful screen with appbar and TODO content
`root_screen`: using switch statements based on user type to navigate to correct screen: hub, maker, or consumer
`user`: allow converting to and from firestore and local data model formats; add id and type field

### New .dart files:
`hub_screen`: basic stateful screen with appbar and TODO content
`locator`: use Getit to use _firestoreUser as a service/util
`firestore_users`: api that links user data model with users collection from firestore; allows for creating users, updating user type, and getting user from id

> Note: added config info for iOS firebase app but need cocaopod installation via xcode

### Demo
![c19bayshield_userselect](https://user-images.githubusercontent.com/25168261/79172440-902c7880-7da9-11ea-8a14-747b167b2cc5.gif)

> Note: no changes on User data model yet (did not create type/role field) 

### Edited screens:
`login_screen`: automatically login at signup and redirect after to choose user type/role

### New screens:
`user_type_screen`: page with user type/role selections and finishes login callback after user selects one, redirecting them to `consumer_screen` (for now)


