### PR TITLE
Signup page for all types (Medical Facility, Collection Hub, Maker)

### DIFF
--- a/lib/screens/hub_signup_screen.dart
+++ b/lib/screens/hub_signup_screen.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+import 'package:supplyside/screens/hub_screen.dart';
+import 'package:supplyside/util/authentication.dart';
+import 'package:supplyside/util/firestore_users.dart';
+import 'package:supplyside/locator.dart';
+import 'package:firebase_database/firebase_database.dart';
+
+class SignUpScreen extends StatefulWidget {
+
+  SignUpScreen({this.userId, this.auth});
+
+  final String userId;
+  final BaseAuth auth;
+
+  @override
+  State<StatefulWidget> createState() => new _SignUpScreenState();
+
+}
+
+class _SignUpScreenState extends State<SignUpScreen>{
+  final _formKey = new GlobalKey<FormState>();
+  final FirestoreUsers _firestoreUsers = locator<FirestoreUsers>();
+
+  String _name;
+  String _email;
+  String _phoneNumber;
+  String _collectionHubName;
+  String _address;
+
+  String _errorMessage;
+  bool _isLoading;
+
+  // Check if form is valid before perform login or signup
+  bool validateAndSave() {
+    final form = _formKey.currentState;
+    if (form.validate()) {
+      form.save();
+      return true;
+    }
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return new Scaffold(
+        appBar: new AppBar(
+          title: new Text('BayShield Collection Hub Signup'),
+          backgroundColor: Color(0xFF313F84),
+        ),
+        body: Stack(
+          children: <Widget>[
+            _showForm()
+          ],
+        ));
+  }
+
+  Future setCollectionHubInfo(String userId, String name, String email,
+      String phoneNumber, String collectionHubName, String address) async {
+    try {
+      await _firestoreUsers.setUserName(userId, name);
+      await _firestoreUsers.setUserEmail(userId, email);
+      await _firestoreUsers.setUserPhoneNumber(userId, phoneNumber);
+      await _firestoreUsers.setUserCollectionHubName(userId, collectionHubName);
+      await _firestoreUsers.setUserAddress(userId, address);
+    } catch (e) {
+      return e.message;
+    }
+  }
+
+  Widget _showForm() {
+    return new Container(
+        padding: EdgeInsets.all(18.0),
+        child: new Form(
+          key: _formKey,
+          child: new ListView(
+            shrinkWrap: true,
+            children: <Widget>[
+              showNameInput(),
+              showEmailInput(),
+              showPhoneNumberInput(),
+              showCollectionHubNameInput(),
+              showAddressInput(),
+              showPrimaryButton(),
+            ],
+          ),
+        ));
+  }
+
+  Widget showNameInput() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(0.0, 40.0, 0.0, 0.0),
+      child: new TextFormField(
+        maxLines: 1,
+        keyboardType: TextInputType.text,
+        autofocus: false,
+        decoration: new InputDecoration(
+            hintText: 'First Last',
+            icon: new Icon(
+              Icons.account_circle,
+              color: Colors.grey,
+            )),
+        validator: (value) => value.isEmpty ? 'Name can\'t be empty' : null,
+        onSaved: (value) => _name = value.trim(),
+      ),
+    );
+  }
+
+  Widget showEmailInput() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(0.0, 15.0, 0.0, 0.0),
+      child: new TextFormField(
+        maxLines: 1,
+        keyboardType: TextInputType.emailAddress,
+        autofocus: false,
+        decoration: new InputDecoration(
+            hintText: 'Email',
+            icon: new Icon(
+              Icons.mail,
+              color: Colors.grey,
+            )),
+        validator: (value) => value.isEmpty ? 'Email can\'t be empty' : null,
+        onSaved: (value) => _email = value.trim(),
+      ),
+    );
+  }
+
+  Widget showPhoneNumberInput() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(0.0, 15.0, 0.0, 0.0),
+      child: new TextFormField(
+        maxLines: 1,
+        keyboardType: TextInputType.phone,
+        autofocus: false,
+        decoration: new InputDecoration(
+            hintText: 'Phone Number',
+            icon: new Icon(
+              Icons.phone,
+              color: Colors.grey,
+            )),
+        validator: (value) => value.isEmpty ? 'Phone number can\'t be empty' : null,
+        onSaved: (value) => _phoneNumber = value.trim(),
+      ),
+    );
+  }
+
+  Widget showCollectionHubNameInput() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(0.0, 15.0, 0.0, 0.0),
+      child: new TextFormField(
+        maxLines: 1,
+        keyboardType: TextInputType.phone,
+        autofocus: false,
+        decoration: new InputDecoration(
+            hintText: 'Collection Hub Name',
+            icon: new Icon(
+              Icons.business,
+              color: Colors.grey,
+            )),
+        validator: (value) => value.isEmpty ? 'Collection hub name can\'t be empty' : null,
+        onSaved: (value) => _collectionHubName = value.trim(),
+      ),
+    );
+  }
+
+  Widget showAddressInput() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(0.0, 15.0, 0.0, 0.0),
+      child: new TextFormField(
+        maxLines: 1,
+        keyboardType: TextInputType.text,
+        autofocus: false,
+        decoration: new InputDecoration(
+            hintText: 'Address',
+            icon: new Icon(
+              Icons.home,
+              color: Colors.grey,
+            )),
+        validator: (value) => value.isEmpty ? 'Address can\'t be empty' : null,
+        onSaved: (value) => _address = value.trim(),
+      ),
+    );
+  }
+
+  Widget showPrimaryButton() {
+    return new Padding(
+        padding: EdgeInsets.fromLTRB(0.0, 45.0, 0.0, 0.0),
+        child: SizedBox(
+          height: 40.0,
+          child: new RaisedButton(
+            elevation: 5.0,
+            shape: new RoundedRectangleBorder(
+                borderRadius: new BorderRadius.circular(30.0)),
+            color: Color(0xFF313F84),
+            child: new Text('Submit',
+                style: new TextStyle(fontSize: 20.0, color: Colors.white)),
+            onPressed: validateAndSubmit,
+          ),
+        ));
+  }
+
+  void validateAndSubmit() async {
+    setState(() {
+      _errorMessage = "";
+      _isLoading = true;
+    });
+    if (validateAndSave()) {
+      try {
+        setCollectionHubInfo(widget.userId, _name, _email,
+            _phoneNumber, _collectionHubName, _address);
+
+        Navigator.pushReplacement(context,
+          MaterialPageRoute(builder: (context) => HubScreen(auth: widget.auth)),
+        );
+      } catch (e) {
+        print('Error: $e');
+        setState(() {
+          _isLoading = false;
+          _errorMessage = e.message;
+          _formKey.currentState.reset();
+        });
+      }
+    }
+  }
+}

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:supplyside/screens/hub_screen.dart';
+import 'package:supplyside/screens/root_screen.dart';
+import 'package:supplyside/screens/user_type_screen.dart';
 import 'package:supplyside/util/authentication.dart';
 import 'package:supplyside/util/firestore_users.dart';
 import 'package:supplyside/locator.dart';
@@ -7,10 +8,11 @@ import 'package:firebase_database/firebase_database.dart';
 
 class SignUpScreen extends StatefulWidget {
 
-  SignUpScreen({this.userId, this.auth});
+  SignUpScreen({this.userId, this.auth, this.label});
 
   final String userId;
   final BaseAuth auth;
+  final String label;
 
   @override
   State<StatefulWidget> createState() => new _SignUpScreenState();
@@ -25,26 +27,17 @@ class _SignUpScreenState extends State<SignUpScreen>{
   String _email;
   String _phoneNumber;
   String _collectionHubName;
+  String _medicalFacilityName;
   String _address;
 
   String _errorMessage;
   bool _isLoading;
 
-  // Check if form is valid before perform login or signup
-  bool validateAndSave() {
-    final form = _formKey.currentState;
-    if (form.validate()) {
-      form.save();
-      return true;
-    }
-    return false;
-  }
-
   @override
   Widget build(BuildContext context) {
     return new Scaffold(
         appBar: new AppBar(
-          title: new Text('BayShield Collection Hub Signup'),
+          title: new Text('BayShield ' + widget.label + ' Signup'),
           backgroundColor: Color(0xFF313F84),
         ),
         body: Stack(
@@ -54,6 +47,34 @@ class _SignUpScreenState extends State<SignUpScreen>{
         ));
   }
 
+  // Check if form is valid before going to root screen
+  bool validateAndSave() {
+    final form = _formKey.currentState;
+    if (form.validate()) {
+      form.save();
+      return true;
+    }
+    return false;
+  }
+
+  // Go to root screen when successfully signed up
+  Future navigateToRootScreen(context, String userId) async {
+    Navigator.pushReplacement(context, MaterialPageRoute(builder: (context) => RootScreen(
+      auth: widget.auth,
+    )
+    ))
+    ;
+  }
+
+  // Go back to user type screen
+  Future navigateToUserTypeScreen(context, String userId) async {
+    Navigator.pushReplacement(context,
+      MaterialPageRoute(builder: (context) => UserTypeScreen(userId:widget.userId, auth: widget.auth,
+      )
+    ))
+    ;
+  }
+
   Future setCollectionHubInfo(String userId, String name, String email,
       String phoneNumber, String collectionHubName, String address) async {
     try {
@@ -61,6 +82,31 @@ class _SignUpScreenState extends State<SignUpScreen>{
       await _firestoreUsers.setUserEmail(userId, email);
       await _firestoreUsers.setUserPhoneNumber(userId, phoneNumber);
       await _firestoreUsers.setUserCollectionHubName(userId, collectionHubName);
+      await _firestoreUsers.setUserAddress(userId, address);
+    } catch (e) {
+      return e.message;
+    }
+  }
+
+  Future setMedicalFacilityInfo(String userId, String name, String email,
+      String phoneNumber, String medicalFacilityName, String address) async {
+    try {
+      await _firestoreUsers.setUserName(userId, name);
+      await _firestoreUsers.setUserEmail(userId, email);
+      await _firestoreUsers.setUserPhoneNumber(userId, phoneNumber);
+      await _firestoreUsers.setMedicalFacilityName(userId, medicalFacilityName);
+      await _firestoreUsers.setUserAddress(userId, address);
+    } catch (e) {
+      return e.message;
+    }
+  }
+
+  Future setMakerInfo(String userId, String name, String email,
+      String phoneNumber, String address) async {
+    try {
+      await _firestoreUsers.setUserName(userId, name);
+      await _firestoreUsers.setUserEmail(userId, email);
+      await _firestoreUsers.setUserPhoneNumber(userId, phoneNumber);
       await _firestoreUsers.setUserAddress(userId, address);
     } catch (e) {
       return e.message;
@@ -78,9 +124,11 @@ class _SignUpScreenState extends State<SignUpScreen>{
               showNameInput(),
               showEmailInput(),
               showPhoneNumberInput(),
-              showCollectionHubNameInput(),
+              if (widget.label == 'Medical Facility') showMedicalFacilityNameInput(),
+              if (widget.label == 'Collection Hub') showCollectionHubNameInput(),
               showAddressInput(),
               showPrimaryButton(),
+              showSecondaryButton(),
             ],
           ),
         ));
@@ -148,7 +196,7 @@ class _SignUpScreenState extends State<SignUpScreen>{
       padding: const EdgeInsets.fromLTRB(0.0, 15.0, 0.0, 0.0),
       child: new TextFormField(
         maxLines: 1,
-        keyboardType: TextInputType.phone,
+        keyboardType: TextInputType.text,
         autofocus: false,
         decoration: new InputDecoration(
             hintText: 'Collection Hub Name',
@@ -158,6 +206,25 @@ class _SignUpScreenState extends State<SignUpScreen>{
             )),
         validator: (value) => value.isEmpty ? 'Collection hub name can\'t be empty' : null,
         onSaved: (value) => _collectionHubName = value.trim(),
+      ),
+    );
+  }
+
+  Widget showMedicalFacilityNameInput() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(0.0, 15.0, 0.0, 0.0),
+      child: new TextFormField(
+        maxLines: 1,
+        keyboardType: TextInputType.text,
+        autofocus: false,
+        decoration: new InputDecoration(
+            hintText: 'Medical Facility Name',
+            icon: new Icon(
+              Icons.business,
+              color: Colors.grey,
+            )),
+        validator: (value) => value.isEmpty ? 'Medical facility name can\'t be empty' : null,
+        onSaved: (value) => _medicalFacilityName = value.trim(),
       ),
     );
   }
@@ -183,17 +250,34 @@ class _SignUpScreenState extends State<SignUpScreen>{
 
   Widget showPrimaryButton() {
     return new Padding(
-        padding: EdgeInsets.fromLTRB(0.0, 45.0, 0.0, 0.0),
+      padding: EdgeInsets.fromLTRB(0.0, 45.0, 0.0, 0.0),
+      child: SizedBox(
+        height: 40.0,
+        child: new RaisedButton(
+          elevation: 5.0,
+          shape: new RoundedRectangleBorder(
+              borderRadius: new BorderRadius.circular(30.0)),
+          color: Color(0xFF313F84),
+          child: new Text('Finish',
+              style: new TextStyle(fontSize: 20.0, color: Colors.white)),
+          onPressed: validateAndSubmit,
+        ),
+      ));
+  }
+
+  Widget showSecondaryButton() {
+    return new Padding(
+        padding: EdgeInsets.fromLTRB(0.0, 15.0, 0.0, 0.0),
         child: SizedBox(
           height: 40.0,
           child: new RaisedButton(
             elevation: 5.0,
             shape: new RoundedRectangleBorder(
                 borderRadius: new BorderRadius.circular(30.0)),
-            color: Color(0xFF313F84),
-            child: new Text('Submit',
-                style: new TextStyle(fontSize: 20.0, color: Colors.white)),
-            onPressed: validateAndSubmit,
+            color: Colors.grey,
+            child: new Text('Back',
+                style: new TextStyle(fontSize: 20.0, color: Colors.black)),
+            onPressed: backToUserType,
           ),
         ));
   }
@@ -205,14 +289,32 @@ class _SignUpScreenState extends State<SignUpScreen>{
     });
     if (validateAndSave()) {
       try {
-        setCollectionHubInfo(widget.userId, _name, _email,
-            _phoneNumber, _collectionHubName, _address);
-
-        Navigator.pushReplacement(context,
-          MaterialPageRoute(builder: (context) => HubScreen(auth: widget.auth)),
-        );
+        switch(widget.label) {
+          case 'Medical Facility': {
+            setMedicalFacilityInfo(widget.userId, _name, _email,
+                _phoneNumber, _medicalFacilityName, _address);
+            navigateToRootScreen(context, widget.userId);
+          }
+          break;
+          case 'Maker': {
+            setMakerInfo(widget.userId, _name, _email,
+                _phoneNumber, _address);
+            navigateToRootScreen(context, widget.userId);
+          }
+          break;
+          case 'Collection Hub': {
+            setCollectionHubInfo(widget.userId, _name, _email,
+                _phoneNumber, _collectionHubName, _address);
+            navigateToRootScreen(context, widget.userId);
+          }
+          break;
+          default: {
+          }
+          break;
+        }
       } catch (e) {
         print('Error: $e');
+
         setState(() {
           _isLoading = false;
           _errorMessage = e.message;
@@ -220,5 +322,9 @@ class _SignUpScreenState extends State<SignUpScreen>{
         });
       }
     }
+  }
+
+  void backToUserType() {
+    navigateToUserTypeScreen(context, widget.userId);
   }
 }

--- a/lib/screens/user_type_screen.dart
+++ b/lib/screens/user_type_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:supplyside/util/authentication.dart';
+import 'package:supplyside/screens/hub_signup_screen.dart';
 import 'package:supplyside/screens/root_screen.dart';
+import 'package:supplyside/util/authentication.dart';
 import 'package:supplyside/util/firestore_users.dart';
 import 'package:supplyside/locator.dart';
 
@@ -61,10 +62,23 @@ class _UserTypeScreenState extends State<UserTypeScreen>{
                 style: new TextStyle(fontSize: 20.0, color: Colors.white)),
             onPressed: () {
               updateUserType(widget.userId, label);
-              Navigator.pushReplacement(
-                context,
-                MaterialPageRoute(builder: (context) => RootScreen(auth: widget.auth)),
-              );
+
+              if (label == 'Medical Facility') {
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(builder: (context) => RootScreen(auth: widget.auth)),
+                );
+              } else if (label == 'Collection Hub') {
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(builder: (context) => HubSignUpScreen(userId: widget.userId, auth: widget.auth)),
+                );
+              } else if (label == 'Maker') {
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(builder: (context) => RootScreen(auth: widget.auth)),
+                );
+              }
             }
           ),
         ))

--- a/lib/screens/user_type_screen.dart
+++ b/lib/screens/user_type_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:supplyside/screens/hub_signup_screen.dart';
-import 'package:supplyside/screens/root_screen.dart';
+import 'package:supplyside/screens/signup_screen.dart';
 import 'package:supplyside/util/authentication.dart';
 import 'package:supplyside/util/firestore_users.dart';
 import 'package:supplyside/locator.dart';
@@ -63,22 +62,10 @@ class _UserTypeScreenState extends State<UserTypeScreen>{
             onPressed: () {
               updateUserType(widget.userId, label);
 
-              if (label == 'Medical Facility') {
-                Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(builder: (context) => RootScreen(auth: widget.auth)),
-                );
-              } else if (label == 'Collection Hub') {
-                Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(builder: (context) => HubSignUpScreen(userId: widget.userId, auth: widget.auth)),
-                );
-              } else if (label == 'Maker') {
-                Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(builder: (context) => RootScreen(auth: widget.auth)),
-                );
-              }
+              Navigator.pushReplacement(
+                context,
+                MaterialPageRoute(builder: (context) => SignUpScreen(userId: widget.userId, auth: widget.auth, label: label)),
+              );
             }
           ),
         ))

--- a/lib/util/firestore_users.dart
+++ b/lib/util/firestore_users.dart
@@ -69,6 +69,15 @@ class FirestoreUsers {
     }
   }
 
+  Future setMedicalFacilityName(String id, String medicalFacilityName) async {
+    try {
+      await _usersCollectionReference.document(id).updateData({"medicalFacilityName": medicalFacilityName});
+      print('Saved medical facility name: $medicalFacilityName');
+    } catch (e) {
+      return e.message;
+    }
+  }
+
   Future setUserAddress(String id, String address) async {
     try {
       await _usersCollectionReference.document(id).updateData({"address": address});

--- a/lib/util/firestore_users.dart
+++ b/lib/util/firestore_users.dart
@@ -32,4 +32,49 @@ class FirestoreUsers {
       return e.message;
     }
   }
+
+  Future setUserName(String id, String name) async {
+    try {
+      await _usersCollectionReference.document(id).updateData({"name": name});
+      print('Saved name: $name');
+    } catch (e) {
+      return e.message;
+    }
+  }
+
+  Future setUserEmail(String id, String email) async {
+    try {
+      await _usersCollectionReference.document(id).updateData({"email": email});
+      print('Saved email: $email');
+    } catch (e) {
+      return e.message;
+    }
+  }
+
+  Future setUserPhoneNumber(String id, String phoneNumber) async {
+    try {
+      await _usersCollectionReference.document(id).updateData({"phoneNumber": phoneNumber});
+      print('Saved phone number: $phoneNumber');
+    } catch (e) {
+      return e.message;
+    }
+  }
+
+  Future setUserCollectionHubName(String id, String collectionHubName) async {
+    try {
+      await _usersCollectionReference.document(id).updateData({"collectionHubName": collectionHubName});
+      print('Saved collection hub name: $collectionHubName');
+    } catch (e) {
+      return e.message;
+    }
+  }
+
+  Future setUserAddress(String id, String address) async {
+    try {
+      await _usersCollectionReference.document(id).updateData({"address": address});
+      print('Saved address: $address');
+    } catch (e) {
+      return e.message;
+    }
+  }
 }


### PR DESCRIPTION
Screencast: https://drive.google.com/file/d/1WMwURSLeo2nfvTLw8b2qTlKsAhlUOB8H/view

Edited screens:
• `signup_screen`: contains all the logic for adding sign-up information for the new user, redirects to `root_screen` once finished
• `user_type_screen`: redirects to `signup_screen` now, rather than `root_screen`

Edited utils:
• `firestore_users`: added new apis to edit fields (email, phone number, address, etc.) for each user's document

