### PR TITLE
signup flow based on UI version-1.1 (frontend + backend changes)

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -23,6 +23,7 @@ class _LoginSignupScreenState extends State<LoginSignupScreen>{
 
   String _email;
   String _password;
+  String _name;
   String _errorMessage;
 
   bool _isLoginForm;
@@ -73,7 +74,8 @@ class _LoginSignupScreenState extends State<LoginSignupScreen>{
             _isLoading = false;
           });
           await widget.auth.signIn(_email, _password);
-          await _firestoreUsers.createUser(User(id: userId, email: _email, type: ""));
+          await _firestoreUsers.createUser(User(id: userId, email: _email, type: "",));
+          await _firestoreUsers.setUserName(userId, _name);
           navigateToUserType(context, userId);
         }
         if (userId.length > 0 && userId != null) {
@@ -195,7 +197,7 @@ class _LoginSignupScreenState extends State<LoginSignupScreen>{
         hint: 'Full Name',
         icon: Icons.account_circle,
         validator: (value) => value.isEmpty ? 'Full Name can\'t be empty' : null,
-        onSaved: (value) { },
+        onSaved: (value) => _name = value.trim(),
       );
     } else {
       return new Container(width: 0.0, height: 0.0);

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -5,6 +5,7 @@ import 'package:supplyside/util/authentication.dart';
 import 'package:supplyside/util/firestore_users.dart';
 import 'package:supplyside/locator.dart';
 import 'package:supplyside/widgets.dart';
+import 'package:supplyside/datamodels/user.dart';
 
 class SignUpScreen extends StatefulWidget {
 
@@ -23,8 +24,6 @@ class _SignUpScreenState extends State<SignUpScreen>{
   final _formKey = new GlobalKey<FormState>();
   final FirestoreUsers _firestoreUsers = locator<FirestoreUsers>();
 
-  String _name;
-  String _email;
   String _phoneNumber;
   String _collectionHubName;
   String _medicalFacilityName;
@@ -32,37 +31,73 @@ class _SignUpScreenState extends State<SignUpScreen>{
 
   String _errorMessage;
   bool _isLoading;
+  User user;
+
+  Future getUser() async {
+   User currUser = await _firestoreUsers.getUser(widget.userId);
+    if (currUser != null) {
+      if (!mounted) return;
+      setState(() {
+        user = currUser;
+      });
+    }
+  }
+
+  Widget buildWaitingScreen() {
+    return Scaffold(
+      body: Container(
+        alignment: Alignment.center,
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
+    getUser();
     Size screenSize = MediaQuery.of(context).size;
-    return Scaffold(
-            body: Stack(
-              children: <Widget>[
-                new FullScreenCover(),
-                SafeArea(
-                  child: ListView(
-                    children: <Widget>[
-                      SizedBox(
-                        height: screenSize.height / 6,
-                      ),
-                      Container(
-                        margin: new EdgeInsets.only(left: 12.0, right: 12.0),
-                        height: screenSize.height / 1.4,
-                        color: Colors.white,
-                        child: Column(
-                          children: <Widget>[
-                            _showForm(),
-                          ]
-                        ),
-                      ),
-                    ],
+    
+    if (user == null) {
+      return buildWaitingScreen();
+    } else { 
+      String name = user.getName() ?? "";
+      return Scaffold(
+        body: Stack(
+          children: <Widget>[
+            new FullScreenCover(),
+            SafeArea(
+              child: ListView(
+                children: <Widget>[
+                    SizedBox(
+                  height: screenSize.height / 6.0,
                   ),
-                ),
-                new BayShieldAppBar(title: widget.label + ' Registration')
-              ]
+                  Container(
+                    margin: new EdgeInsets.only(left: 12.0, right: 12.0),
+                    child: Column(
+                      children: <Widget>[
+                        Image.asset('assets/images/logo_small.png', height: 100, width: 100),
+                        new UserTypeTagBlue(userTag: widget.label),
+                        SizedBox(
+                          height: 16,
+                        ),
+                        Text(
+                          "Hi " + name + "!",
+                          style: TextStyle(
+                              fontSize: 28.0,
+                              color: Colors.white,
+                              fontWeight: FontWeight.w700),
+                          ),
+                        _showForm(),
+                      ]
+                    ),
+                  ),
+                ],
+              ),
             ),
-    );
+          ]
+        ),
+      );
+    }
   }
 
   // Check if form is valid before going to root screen
@@ -93,11 +128,9 @@ class _SignUpScreenState extends State<SignUpScreen>{
     ;
   }
 
-  Future setCollectionHubInfo(String userId, String name, String email,
+  Future setCollectionHubInfo(String userId, 
       String phoneNumber, String collectionHubName, String address) async {
     try {
-      await _firestoreUsers.setUserName(userId, name);
-      await _firestoreUsers.setUserEmail(userId, email);
       await _firestoreUsers.setUserPhoneNumber(userId, phoneNumber);
       await _firestoreUsers.setUserCollectionHubName(userId, collectionHubName);
       await _firestoreUsers.setUserAddress(userId, address);
@@ -106,11 +139,9 @@ class _SignUpScreenState extends State<SignUpScreen>{
     }
   }
 
-  Future setMedicalFacilityInfo(String userId, String name, String email,
+  Future setMedicalFacilityInfo(String userId, 
       String phoneNumber, String medicalFacilityName, String address) async {
     try {
-      await _firestoreUsers.setUserName(userId, name);
-      await _firestoreUsers.setUserEmail(userId, email);
       await _firestoreUsers.setUserPhoneNumber(userId, phoneNumber);
       await _firestoreUsers.setMedicalFacilityName(userId, medicalFacilityName);
       await _firestoreUsers.setUserAddress(userId, address);
@@ -119,11 +150,9 @@ class _SignUpScreenState extends State<SignUpScreen>{
     }
   }
 
-  Future setMakerInfo(String userId, String name, String email,
+  Future setMakerInfo(String userId, 
       String phoneNumber, String address) async {
     try {
-      await _firestoreUsers.setUserName(userId, name);
-      await _firestoreUsers.setUserEmail(userId, email);
       await _firestoreUsers.setUserPhoneNumber(userId, phoneNumber);
       await _firestoreUsers.setUserAddress(userId, address);
     } catch (e) {
@@ -139,37 +168,36 @@ class _SignUpScreenState extends State<SignUpScreen>{
           child: new ListView(
             shrinkWrap: true,
             children: <Widget>[
-              showNameInput(),
-              showEmailInput(),
+              // showNameInput(),
+              // showEmailInput(),
               showPhoneNumberInput(),
               if (widget.label == 'Medical Facility') showMedicalFacilityNameInput(),
               if (widget.label == 'Collection Hub') showCollectionHubNameInput(),
               showAddressInput(),
               new SizedBox(height: 24),
-              new PrimaryButton(submit: validateAndSubmit, label: "REGISTER"),
-              new PrimaryButton(submit: backToUserType, label: "BACK"),
+              new PrimaryButton(submit: validateAndSubmit, label: "Get Started"),
             ],
           ),
         ));
   }
 
-  Widget showNameInput() {
-    return new BayShieldFormField(
-      hint: 'First Last', 
-      icon: Icons.account_circle,
-      validator: (value) => value.isEmpty ? 'Name can\'t be empty' : null,
-      onSaved: (value) => _name = value.trim(),
-    );
-  }
+  // Widget showNameInput() {
+  //   return new BayShieldFormField(
+  //     hint: 'First Last', 
+  //     icon: Icons.account_circle,
+  //     validator: (value) => value.isEmpty ? 'Name can\'t be empty' : null,
+  //     onSaved: (value) => _name = value.trim(),
+  //   );
+  // }
 
-  Widget showEmailInput() {
-    return new BayShieldFormField(
-      hint: 'Email',
-      icon: Icons.mail,
-      validator: (value) => value.isEmpty ? 'Email can\'t be empty' : null,
-      onSaved: (value) => _email = value.trim(),
-    );
-  }
+  // Widget showEmailInput() {
+  //   return new BayShieldFormField(
+  //     hint: 'Email',
+  //     icon: Icons.mail,
+  //     validator: (value) => value.isEmpty ? 'Email can\'t be empty' : null,
+  //     onSaved: (value) => _email = value.trim(),
+  //   );
+  // }
 
   Widget showPhoneNumberInput() {
     return new BayShieldFormField(
@@ -216,19 +244,19 @@ class _SignUpScreenState extends State<SignUpScreen>{
       try {
         switch(widget.label) {
           case 'Medical Facility': {
-            setMedicalFacilityInfo(widget.userId, _name, _email,
+            setMedicalFacilityInfo(widget.userId, 
                 _phoneNumber, _medicalFacilityName, _address);
             navigateToRootScreen(context, widget.userId);
           }
           break;
           case 'Maker': {
-            setMakerInfo(widget.userId, _name, _email,
+            setMakerInfo(widget.userId, 
                 _phoneNumber, _address);
             navigateToRootScreen(context, widget.userId);
           }
           break;
           case 'Collection Hub': {
-            setCollectionHubInfo(widget.userId, _name, _email,
+            setCollectionHubInfo(widget.userId,
                 _phoneNumber, _collectionHubName, _address);
             navigateToRootScreen(context, widget.userId);
           }

--- a/lib/screens/user_type_screen.dart
+++ b/lib/screens/user_type_screen.dart
@@ -31,58 +31,33 @@ class _UserTypeScreenState extends State<UserTypeScreen>{
   Widget build(BuildContext context) {
     Size screenSize = MediaQuery.of(context).size;
 
-    Widget promptSection = Container(
-      padding: const EdgeInsets.only(top: 94.0),
-      child: Text(
-        'Sign Up as a...',
-        textAlign: TextAlign.center,
-        softWrap: true,
-        style: TextStyle(
-          fontSize: 24.0,
-          fontWeight: FontWeight.w700,
-        ),
-      ),
-    );
-
-  Column _buildButtonColumn(IconData icon, String label) {
+  Column _buildButtonColumn(String label) {
     return Column(
       mainAxisSize: MainAxisSize.min,
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
         Container(
-          margin: const EdgeInsets.only(top: 32, bottom: 32),
+          margin: const EdgeInsets.only(top: 16, bottom: 16),
           child: SizedBox(
-          height: screenSize.height / 7.7,
           child: new RaisedButton(
+            color: Color(0xFF697CC8), 
             elevation: 5.0,
-            padding: EdgeInsets.all(0.0),
-            child: Ink(
-              decoration: BoxDecoration(
-                  gradient: LinearGradient(colors: [Color(0xD68134), Color(0xF5B819), Color(0xFFE6B819)],
-                    begin: Alignment.centerLeft,
-                    end: Alignment.centerRight,
-                  ),
-                  borderRadius: BorderRadius.circular(10.0)
-              ),
+            padding: EdgeInsets.all(16.0),
               child: Container(
-                padding: EdgeInsets.only(top: 12),
-                constraints: BoxConstraints(maxWidth: screenSize.width / 1.7, minHeight: 70.0),
+                constraints: BoxConstraints(maxWidth: screenSize.width / 1.7),
                 alignment: Alignment.center,
                 child: Column( 
                   children: <Widget>[
-                    Icon(icon, color: Colors.white, size: 28.0),
-                    new SizedBox(height: 6),
                     new Text(label,
-                      style: new TextStyle(fontSize: 20.0, color: Colors.white)),
+                      style: new TextStyle(fontSize: 25.0, color: Colors.white,  fontWeight: FontWeight.w400)),
                   ]
                 ),
               ),
-            ),
             shape: new RoundedRectangleBorder(
                 borderRadius: new BorderRadius.circular(10.0)),
             onPressed: () {
               updateUserType(widget.userId, label);
-              Navigator.pushReplacement(
+              Navigator.push(
                 context,
                 MaterialPageRoute(builder: (context) => SignUpScreen(userId: widget.userId, auth: widget.auth, label: label)),
               );
@@ -94,13 +69,13 @@ class _UserTypeScreenState extends State<UserTypeScreen>{
   }
 
     Widget buttonSection = Container(
-      margin: const EdgeInsets.only(top: 32),
+      margin: const EdgeInsets.only(top: 24),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
-          _buildButtonColumn(Icons.local_hospital, 'Medical Facility'),
-          _buildButtonColumn(Icons.share, 'Collection Hub'),
-          _buildButtonColumn(Icons.lightbulb_outline, 'Maker'),
+          _buildButtonColumn('Maker'),
+          _buildButtonColumn('Collection Hub'),
+          _buildButtonColumn('Medical Organization'),
         ],
       ),
     );
@@ -110,9 +85,31 @@ class _UserTypeScreenState extends State<UserTypeScreen>{
               children: <Widget>[
                 new FullScreenCover(),
                 ListView(
-                  children: [promptSection, buttonSection],
+                  children: <Widget>[
+                    SizedBox(
+                      height: screenSize.height / 6.0,
+                    ),
+                    Container(
+                      margin: new EdgeInsets.only(left: 12.0, right: 12.0),
+                      child: Column(
+                        children: <Widget>[
+                          Image.asset('assets/images/logo_small.png', height: 100, width: 100),
+                          SizedBox(
+                            height: 20,
+                          ),
+                          Text(
+                            "I am a...",
+                            style: TextStyle(
+                                fontSize: 28.0,
+                                color: Colors.white,
+                                fontWeight: FontWeight.w700),
+                            ),
+                          buttonSection,
+                        ]
+                      ),
+                    ),
+                  ],
                 ),
-                  new BayShieldAppBar(title: 'BayShield')
               ]
             ),
     );

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -70,6 +70,28 @@ class UserTypeTag extends StatelessWidget {
   }
 }
 
+class UserTypeTagBlue extends StatelessWidget {
+  final String userTag;
+
+  UserTypeTagBlue({Key key, @required this.userTag}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return new Container(
+      margin: new EdgeInsets.only(top: 6.0),
+      color: Colors.transparent,
+      child: Container(
+        padding: new EdgeInsets.only(top: 4.0, bottom: 4.0, left: 8.0, right: 8.0),
+        decoration: BoxDecoration(
+            color: Color(0xFF697CC8), 
+            borderRadius: BorderRadius.all(Radius.circular(5.0))),
+            child: new Text(userTag.toUpperCase(),
+              style: TextStyle(color: Colors.white, fontSize: 15, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,),
+      )
+    );
+  }
+}
+
 class AlertTag extends StatelessWidget {
   final String message;
 


### PR DESCRIPTION
**Overview:** sign in flow matches version-1.1 on [figma](https://www.figma.com/file/luXCAxL3U4z5CuETmOpyLn/April06-mockups?node-id=655%3A1296)

**Demo:**
![Screen Shot 2020-06-09 at 5 08 11 PM](https://user-images.githubusercontent.com/25168261/84212846-d03f6d00-aa73-11ea-9ce0-f41cdc1171b0.png)
![Screen Shot 2020-06-09 at 4 54 55 PM](https://user-images.githubusercontent.com/25168261/84212849-d1709a00-aa73-11ea-915c-a8e8edede9fa.png)


**Edited screens:**
- `login_screen`: add name field and push value to firestore before other values
- `user_type_screen`: UI changes only to match figma
- `signup_screen`: UI matches version 1.1 minus additional phone #/facility name type, add getUser request to get name to display, remove redundant email and name fields 


**New widgets:**
• `UserTypeTagBlue`: blue-ish tag that displays the user type for sign up info screen