### PR TITLE
Medorgs UI: Orders, Home, and Profile Settings (minus Status)

### DIFF
--- a/lib/datamodels/user.dart
+++ b/lib/datamodels/user.dart
@@ -51,7 +51,7 @@ class User {
 
 class MedicalFacility extends User {
 
-  MedicalFacility({id, String email, int phoneNumber, this.address, @required this.medicalFacilityName, this.staffSize}) :
+  MedicalFacility({id, String email, String phoneNumber, this.address, @required this.medicalFacilityName, this.staffSize}) :
     super(
       id: id, 
       email: email, 
@@ -64,6 +64,7 @@ class MedicalFacility extends User {
       email = data['email'],
       name = data['name'],
       address = data['address'],
+      phoneNumber = data['phoneNumber'],
       medicalFacilityName = data['medicalFacilityName'];
 
   String getFacilityName() {
@@ -78,5 +79,6 @@ class MedicalFacility extends User {
   int staffSize;
   String contactPersonName;
   String contactPersonTitle;
+  String phoneNumber;
 
 }

--- a/lib/screens/consumer_screen.dart
+++ b/lib/screens/consumer_screen.dart
@@ -261,22 +261,9 @@ class _ConsumerScreenState extends State<ConsumerScreen> {
                                 padding: EdgeInsets.only(top: 30, bottom: 25)
                             )
                         ),
-                        Container(
-                          decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                            color: Color(0xFFD2D2D2),
-                          ),
-                            child: ToggleButtons(
-                          fillColor: Color(0xFFB7CDFF),
-                          borderWidth: 0.0,
-                          constraints: BoxConstraints(minWidth: (MediaQuery.of(context).size.width - 110)/2, minHeight: MediaQuery.of(context).size.height / 25),
-                          borderRadius: BorderRadius.all(Radius.circular(10.0)),
-                          children: <Widget>[
-                            new Text("Profile", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
-                              textAlign: TextAlign.center,),
-                            new Text("Status", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
-                              textAlign: TextAlign.center,),
-                          ],
+                        TwoToggle(
+                          left: "Profile",
+                          right: "Status",
                           onPressed: (int index) {
                             setState(() {
                               _isSelectedProfilePage[index] = true;
@@ -289,7 +276,6 @@ class _ConsumerScreenState extends State<ConsumerScreen> {
                             });
                           },
                           isSelected: _isSelectedProfilePage,
-                        ),
                         ),
                         if (_displayStatus) new Text("TODO: Organization Details", style: TextStyle(color: Colors.black, fontSize: 25, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
                           textAlign: TextAlign.left,),

--- a/lib/screens/consumer_screen.dart
+++ b/lib/screens/consumer_screen.dart
@@ -172,6 +172,11 @@ class _ConsumerScreenState extends State<ConsumerScreen> {
     }
   }
 
+  void _onPendingPressed() {
+    _index = 1;
+    _onNavigationIconTapped(0);
+  }
+
   Widget buildHomePage() {
     String firstName = user.getName().split(" ")[0];
     String _greeting = "Hi, " + firstName + ".";
@@ -208,7 +213,7 @@ class _ConsumerScreenState extends State<ConsumerScreen> {
                                       height: MediaQuery.of(context).size.height / 7,
                                       width: (MediaQuery.of(context).size.width - 120) / 2,
                                       color: Colors.transparent,
-                                      child: new PendingItemsCard(pending: _pending, onPressed: () => {}),
+                                      child: new PendingItemsCard(pending: _pending, onPressed: _onPendingPressed),
                                     ),
                                     Container(
                                       height: MediaQuery.of(context).size.height / 7,
@@ -256,7 +261,8 @@ class _ConsumerScreenState extends State<ConsumerScreen> {
                             width: MediaQuery.of(context).size.width - 110,
                             color: Colors.transparent,
                             child: new Padding(
-                                child: new Text(_greeting, style: TextStyle(color: Colors.black, fontSize: 45, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+                                child: new Text(_greeting, style: TextStyle(color: Colors.black, 
+                                fontSize: 45, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
                                   textAlign: TextAlign.left,),
                                 padding: EdgeInsets.only(top: 30, bottom: 25)
                             )
@@ -290,6 +296,42 @@ class _ConsumerScreenState extends State<ConsumerScreen> {
     );
   }
 
+  Widget buildOrdersPage() {
+    return new Scaffold(
+      backgroundColor: Colors.white,
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(MediaQuery.of(context).size.height / 10),
+        child: new MainAppBar(signOut: signOut),
+      ),
+      body: SafeArea(
+        child: new SingleChildScrollView(
+          child: new Container(
+              child: Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: <Widget>[
+                      Container(
+                          width: MediaQuery.of(context).size.width - 110,
+                          color: Colors.transparent,
+                          child: new Padding(
+                              child: new Text("Orders", style: TextStyle(color: Colors.black, fontSize: 45, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+                                textAlign: TextAlign.left,),
+                              padding: EdgeInsets.only(top: 30, bottom: 25)
+                          )
+                      ),
+                     _buildRequestList(),
+                     new NewOrderButton(onPressed: () => Navigator.pushNamed(context, REQUEST_SCREEN),),
+                    ],
+                  )
+              )
+          )
+        ),
+      ),
+      bottomNavigationBar: new MainBottomNavigationBar(selectedIndex: _selectedIndex , onItemTapped: _onNavigationIconTapped),
+    );
+  }
+
+
 
   @override
   Widget build(BuildContext context) {
@@ -298,14 +340,7 @@ class _ConsumerScreenState extends State<ConsumerScreen> {
       return buildWaitingScreen();
     } else {
       if (_selectedIndex == 0) {
-        if (_addButtonPressed) {
-          // return buildConfirmationPage();
-          return buildHomePage();
-        } else if (_arrowPressed) {
-          // return buildShippingPage();
-          return buildHomePage();
-        }
-        // return buildOrdersPage();
+        return buildOrdersPage();
       } else if (_selectedIndex == 1) {
         return buildHomePage();
       } else if (_selectedIndex == 2) {

--- a/lib/screens/consumer_screen.dart
+++ b/lib/screens/consumer_screen.dart
@@ -7,6 +7,7 @@ import 'package:supplyside/util/authentication.dart';
 import 'package:supplyside/util/firestore_users.dart';
 import 'package:supplyside/locator.dart';
 import 'package:supplyside/widgets.dart';
+import 'package:supplyside/state_widgets.dart';
 
 
 class ConsumerScreen extends StatefulWidget {
@@ -35,7 +36,6 @@ class _ConsumerScreenState extends State<ConsumerScreen> {
   TextStyle orderSubtitleStyle = TextStyle(fontSize: 14.0,letterSpacing: .5, color: Color(0xFFA5A9B4));
   String _message = "Alert: PPE Design Update. Read More";
   int _pending = 4;
-  int _shipped = 100;
   int _newQuantity = 0;
 
   int _index = 0;
@@ -50,9 +50,9 @@ class _ConsumerScreenState extends State<ConsumerScreen> {
   bool _displayPending = false;
   bool _displayShipped = false;
 
-  List<bool> _isSelectedProfilePage = [true, false]; // defaults at Inventory tab.
-  bool _displayInventory = true;
-  bool _displaySettings = false;
+  bool _displaySettings = true;
+  bool _displayStatus = false;
+  List<bool> _isSelectedProfilePage = [true, false]; 
 
 
   void _onNavigationIconTapped(int index) {
@@ -63,16 +63,16 @@ class _ConsumerScreenState extends State<ConsumerScreen> {
       _arrowPressed = false;
       _editButtonPressed = false;
       _initialized = false;
-      _displayInventory = true;
-      _displaySettings = false;
+      _displayStatus = false;
+      _displaySettings = true;
 
       nameController.clear();
       emailController.clear();
       phoneNumberController.clear();
       addressController.clear();
 
-      _isSelectedProfilePage[0] = _displayInventory;
-      _isSelectedProfilePage[1] = _displaySettings;
+      _isSelectedProfilePage[0] = _displaySettings;
+      _isSelectedProfilePage[1] = _displayStatus;
       build(context);
     });
   }
@@ -86,38 +86,6 @@ class _ConsumerScreenState extends State<ConsumerScreen> {
         user = currUser;
       });
     }
-  }
-
-  Widget _buildCoverImage(Size screenSize) {
-    return Container(
-      height: screenSize.height / 2.8,
-      decoration: BoxDecoration(
-        image: DecorationImage(
-          image: AssetImage('assets/images/bgcover.png'),
-          fit: BoxFit.cover,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildAddress() {
-    TextStyle bioTextStyle = TextStyle(
-      fontFamily: 'Spectral',
-      fontWeight: FontWeight.w400,//try changing weight to w500 if not thin
-      fontStyle: FontStyle.italic,
-      color: Color(0xFF799497),
-      fontSize: 16.0,
-    );
-
-    return Container(
-      color: Colors.white,
-      padding: EdgeInsets.all(8.0),
-      child: Text(
-        user.getAddress() ?? "",
-        textAlign: TextAlign.center,
-        style: bioTextStyle,
-      ),
-    );
   }
 
   Widget _buildRequestItem(SupplyRequest req, BuildContext context) {
@@ -246,7 +214,7 @@ class _ConsumerScreenState extends State<ConsumerScreen> {
                                       height: MediaQuery.of(context).size.height / 7,
                                       width: (MediaQuery.of(context).size.width - 120) / 2,
                                       color: Colors.transparent,
-                                      child: new ShippedItemsCard(shipped: _shipped, onPressed: () => {}),
+                                      child: new ShippedItemsCard(shipped: 100, onPressed: () => {}),
                                     ),
                                   ]
                               )
@@ -267,25 +235,96 @@ class _ConsumerScreenState extends State<ConsumerScreen> {
       }
   }
 
+  Widget buildProfilePage() {
+    String _greeting = "Settings";
+
+    return new Scaffold(
+      resizeToAvoidBottomPadding: false,
+      backgroundColor: Colors.white,
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(MediaQuery.of(context).size.height / 10),
+        child: new MainAppBar(signOut: signOut),
+      ),
+      body: SafeArea(
+        child: new SingleChildScrollView(
+          child: new Container(
+              child: Center(
+                  child: Column(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      children: <Widget>[
+                        Container(
+                            width: MediaQuery.of(context).size.width - 110,
+                            color: Colors.transparent,
+                            child: new Padding(
+                                child: new Text(_greeting, style: TextStyle(color: Colors.black, fontSize: 45, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+                                  textAlign: TextAlign.left,),
+                                padding: EdgeInsets.only(top: 30, bottom: 25)
+                            )
+                        ),
+                        Container(
+                          decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(10),
+                            color: Color(0xFFD2D2D2),
+                          ),
+                            child: ToggleButtons(
+                          fillColor: Color(0xFFB7CDFF),
+                          borderWidth: 0.0,
+                          constraints: BoxConstraints(minWidth: (MediaQuery.of(context).size.width - 110)/2, minHeight: MediaQuery.of(context).size.height / 25),
+                          borderRadius: BorderRadius.all(Radius.circular(10.0)),
+                          children: <Widget>[
+                            new Text("Profile", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+                              textAlign: TextAlign.center,),
+                            new Text("Status", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+                              textAlign: TextAlign.center,),
+                          ],
+                          onPressed: (int index) {
+                            setState(() {
+                              _isSelectedProfilePage[index] = true;
+                              _isSelectedProfilePage[1 - index] = false;
+                              _displaySettings = _isSelectedProfilePage[0];
+                              _displayStatus = _isSelectedProfilePage[1];
+                              if (_displaySettings) {
+                                _editButtonPressed = false;
+                              }
+                            });
+                          },
+                          isSelected: _isSelectedProfilePage,
+                        ),
+                        ),
+                        if (_displayStatus) new Text("TODO: Organization Details", style: TextStyle(color: Colors.black, fontSize: 25, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+                          textAlign: TextAlign.left,),
+                        if (_displaySettings) new ProfileSettings(user: user, title: "Personal Information"),
+                      ]
+                  )
+              )
+          )
+        ),
+      ),
+      bottomNavigationBar: new MainBottomNavigationBar(selectedIndex: _selectedIndex, onItemTapped: _onNavigationIconTapped),
+    );
+  }
+
+
   @override
   Widget build(BuildContext context) {
     getUser();
     if (user == null) {
       return buildWaitingScreen();
     } else {
-      return buildHomePage();
-      // if (_selectedIndex == 0) {
-      //   if (_addButtonPressed) {
-      //     return buildConfirmationPage();
-      //   } else if (_arrowPressed) {
-      //     return buildShippingPage();
-      //   }
-      //   return buildOrdersPage();
-      // } else if (_selectedIndex == 1) {
-      //   return buildHomePage();
-      // } else if (_selectedIndex == 2) {
-      //   return buildProfilePage();
-      // }
+      if (_selectedIndex == 0) {
+        if (_addButtonPressed) {
+          // return buildConfirmationPage();
+          return buildHomePage();
+        } else if (_arrowPressed) {
+          // return buildShippingPage();
+          return buildHomePage();
+        }
+        // return buildOrdersPage();
+      } else if (_selectedIndex == 1) {
+        return buildHomePage();
+      } else if (_selectedIndex == 2) {
+        return buildProfilePage();
+      }
     }
   }
 }

--- a/lib/screens/consumer_screen.dart
+++ b/lib/screens/consumer_screen.dart
@@ -89,58 +89,41 @@ class _ConsumerScreenState extends State<ConsumerScreen> {
   }
 
   Widget _buildRequestItem(SupplyRequest req, BuildContext context) {
-    double c_width = MediaQuery.of(context).size.width;
-    return Column(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget> [
-        Container(
-          width: c_width * .8,
-          color: Color(0xFF313F84),
-          padding: EdgeInsets.symmetric(vertical: 8, horizontal: 8),
-          child: 
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                Container(
-                  margin: EdgeInsets.only(right: 16),
-                  child: ClipRRect(
-                  borderRadius: BorderRadius.circular(8.0),
-                  child: Image.network(req.item.imageUrl, 
-                    width: 64, 
-                    height: 64,
-                    fit: BoxFit.fill
-                  ),
-                ),
-                ),
-                Column(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Row(mainAxisSize: MainAxisSize.min,children: <Widget>[Text(req.item.name, style: Theme.of(context).textTheme.headline3,), SizedBox(width: 16),],),
-                    Text('${req.amtOrdered.toString()} Ordered', style: Theme.of(context).textTheme.subtitle2 ),
-                    Text('${req.statusToString()}', style: Theme.of(context).textTheme.subtitle2)
-                  ],
-                )
-              ],
-            ),
-          ),
-        Container(
-          color: Color(0xFFFFFFFF),
-          width: c_width * .8,
-          child: Padding(
-            padding: EdgeInsets.symmetric(horizontal: 8, vertical: 8),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                Text('Order #DOJF837D', style: this.orderStyle,),
-                Text('Order Date - 06 May 2020', style: this.orderSubtitleStyle)
-              ],
+    String asset = req.item.imageUrl ?? "assets/images/logo.png";
+    String itemName =  req.item.name;
+    int quantity = req.amtOrdered;
+
+    return new ItemCard(asset: asset, itemName: itemName, quantity: quantity, 
+      itemType: "USCF V1", date: "06 May 2020", hasShipped: true, isPending: false,
+      status: req.statusToString(),  
+      deliveryLocation: user.getFacilityName(),
+      deliveryDate: "10 May 2020",
+    );
+  }
+
+    Widget showShippedItems() {
+    // TODO: replace hard-coded values.
+    String asset = "assets/images/face_shield_icon.png";
+    String itemName = "Face Shield";
+    int quantity = 50;
+    String itemType = "USCF V1";
+    String date = "02/01/2020";
+    String status = "Expected\nDelivery";
+    String deliveryDate = "02/06/2020";
+    String deliveryLocation = "Tang Center";
+
+    return new Padding (
+        padding: EdgeInsets.only(top: 16.0, bottom: 16.0),
+        child: Container(
+            width: MediaQuery.of(context).size.width - 80,
+            child: new Column (
+                children: <Widget> [
+                  new ItemCard(asset: asset, itemName: itemName, quantity: quantity, itemType: itemType, date: date, hasShipped: true, isPending: false,
+                    status: status, deliveryDate: deliveryDate, deliveryLocation: deliveryLocation),
+                ]
             )
-          ),
         )
-        ]
-      );
+    );
   }
 
   Widget _buildRequestList() {
@@ -319,8 +302,8 @@ class _ConsumerScreenState extends State<ConsumerScreen> {
                               padding: EdgeInsets.only(top: 30, bottom: 25)
                           )
                       ),
-                     _buildRequestList(),
-                     new NewOrderButton(onPressed: () => Navigator.pushNamed(context, REQUEST_SCREEN),),
+                     showShippedItems(),
+                     new NewOrderPlus(onPressed: () => Navigator.pushNamed(context, REQUEST_SCREEN),),
                     ],
                   )
               )

--- a/lib/screens/hub_screen.dart
+++ b/lib/screens/hub_screen.dart
@@ -33,7 +33,7 @@ class _HubScreenState extends State<HubScreen>{
   int _incoming = 10;
   int _pending = 35;
   int _shipped = 13430;
-  String _userType = "C O L L E C T I O N  H U B";
+  String _userType = "COLLECTION HUB";
   String _message = "Alert: PPE Design Update. Read More";
 
   ItemConfirmationCard _itemConfirmationCard;

--- a/lib/screens/hub_screen.dart
+++ b/lib/screens/hub_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:supplyside/util/authentication.dart';
 import 'package:supplyside/widgets.dart';
+import 'package:supplyside/state_widgets.dart';
 import 'package:supplyside/locator.dart';
 import 'package:supplyside/datamodels/user.dart';
 import 'package:supplyside/util/firestore_users.dart';
@@ -114,13 +115,6 @@ class _HubScreenState extends State<HubScreen>{
     build(context);
   }
 
-  void _onEditButtonPressed() {
-    _selectedIndex = 2;
-    _editButtonPressed = !_editButtonPressed;
-    _initialized = false;
-    clearControllers();
-    build(context);
-  }
 
   void signOut() async {
     try {
@@ -561,19 +555,9 @@ class _HubScreenState extends State<HubScreen>{
                                 padding: EdgeInsets.only(top: 30, bottom: 25)
                             )
                         ),
-                        ToggleButtons(
-                          fillColor: Color(0xFFB7CDFF),
-                          borderColor: Color(0xFFB2B2B2),
-                          selectedBorderColor: Color(0xFFB2B2B2),
-                          borderWidth: 2.0,
-                          constraints: BoxConstraints(minWidth: (MediaQuery.of(context).size.width - 110)/2, minHeight: MediaQuery.of(context).size.height / 25),
-                          borderRadius: BorderRadius.all(Radius.circular(10.0)),
-                          children: <Widget>[
-                            new Text("Inventory", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
-                              textAlign: TextAlign.center,),
-                            new Text("Settings", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
-                              textAlign: TextAlign.center,),
-                          ],
+                        new TwoToggle(
+                          left: "Inventory",
+                          right: "Settings",
                           onPressed: (int index) {
                             setState(() {
                               _isSelectedProfilePage[index] = true;
@@ -589,7 +573,7 @@ class _HubScreenState extends State<HubScreen>{
                         ),
                         if (_displayInventory) new Text("Inventory", style: TextStyle(color: Colors.black, fontSize: 25, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
                           textAlign: TextAlign.left,),
-                        if (_displaySettings) showSettings(),
+                        if (_displaySettings) new ProfileSettings(user: user, title: ""),
                       ]
                   )
               )
@@ -611,181 +595,6 @@ class _HubScreenState extends State<HubScreen>{
     }
   }
 
-  Widget showSettings() {
-    return new Padding (
-      padding: EdgeInsets.only(top: 10.0),
-      child: Container(
-        width: MediaQuery.of(context).size.width - 100,
-        child: new Column (
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.start,
-          children: <Widget>[
-            new Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: <Widget>[
-                new IconButton(
-                  onPressed: _onEditButtonPressed,
-                  icon: Image.asset("assets/images/edit_button.png", height: 26, alignment: Alignment.centerRight),
-                )
-              ]
-            ),
-            SizedBox(height: 5),
-            new Row(
-              mainAxisAlignment: MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: <Widget>[
-                new Container(
-                  width: MediaQuery.of(context).size.width * 0.25,
-                  child: new Text("Name", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
-                    textAlign: TextAlign.left,)
-                ),
-                if (!_editButtonPressed)
-                  new Container(
-                    width: MediaQuery.of(context).size.width * 0.5,
-                    child: new Text(user.getName(), style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
-                      textAlign: TextAlign.left,),
-                  ),
-                if (_editButtonPressed)
-                  new Container(
-                      width: MediaQuery.of(context).size.width * 0.5,
-                      child: new EditFormField(
-                        controller: nameController,
-                        type: TextInputType.text,
-                        hint: user.getName(),
-                        maxLines: 1,
-                      )
-                  ),
-              ]
-            ),
-            SizedBox(height: 10),
-            new Row(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: <Widget>[
-                  new Container(
-                      width: MediaQuery.of(context).size.width * 0.25,
-                      child: new Text("Email", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
-                        textAlign: TextAlign.left,)
-                  ),
-                  if (!_editButtonPressed)
-                    new Container(
-                      width: MediaQuery.of(context).size.width * 0.5,
-                      child: new Text(user.getEmail(), style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
-                        textAlign: TextAlign.left,),
-                    ),
-                  if (_editButtonPressed)
-                    new Container(
-                        width: MediaQuery.of(context).size.width * 0.5,
-                        child: new EditFormField(
-                          controller: emailController,
-                          type: TextInputType.text,
-                          hint: user.getEmail(),
-                          maxLines: 1,
-                        )
-                    ),
-                ]
-            ),
-            SizedBox(height: 10),
-            new Row(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: <Widget>[
-                  new Container(
-                      width: MediaQuery.of(context).size.width * 0.25,
-                      child: new Text("Phone", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
-                        textAlign: TextAlign.left,)
-                  ),
-                  if (!_editButtonPressed)
-                    new Container(
-                      width: MediaQuery.of(context).size.width * 0.5,
-                      child: new Text(user.getPhoneNumber(), style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
-                        textAlign: TextAlign.left,),
-                    ),
-                  if (_editButtonPressed)
-                    new Container(
-                        width: MediaQuery.of(context).size.width * 0.5,
-                        child: new EditFormField(
-                          controller: phoneNumberController,
-                          type: TextInputType.number,
-                          hint: user.getPhoneNumber(),
-                          formatter: <TextInputFormatter>[
-                            WhitelistingTextInputFormatter.digitsOnly
-                          ],
-                          maxLines: 1,
-                        )
-                    ),
-                ]
-            ),
-            SizedBox(height: 10),
-            new Row(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: <Widget>[
-                  new Container(
-                      width: MediaQuery.of(context).size.width * 0.25,
-                      child: new Text("Address", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
-                        textAlign: TextAlign.left,)
-                  ),
-                  if (!_editButtonPressed)
-                    new Container(
-                      width: MediaQuery.of(context).size.width * 0.5,
-                      child: new Text(user.getAddress(), style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
-                        textAlign: TextAlign.left,),
-                    ),
-                  if (_editButtonPressed)
-                    new Container(
-                        width: MediaQuery.of(context).size.width * 0.5,
-                      child: new EditFormField(
-                        controller: addressController,
-                        type: TextInputType.text,
-                        hint: user.getAddress(),
-                        maxLines: 1,
-                      )
-                    ),
-                ]
-            ),
-            SizedBox(height: 20),
-            if (_editButtonPressed)
-              new Row (
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: <Widget>[
-                    new Padding (
-                      padding: EdgeInsets.only(right: 4),
-                      child: new Container(
-                          width: (MediaQuery.of(context).size.width - 120) * 0.5,
-                          child: new FlatButton(
-                            child: new Text("Save",
-                              style: TextStyle(color: Color(0xFF283568), fontSize: 20, fontFamily: 'Roboto', fontWeight: FontWeight.bold, decoration: TextDecoration.underline),
-                              textAlign: TextAlign.center,),
-                            onPressed: () {
-                              updateUser();
-                              _editButtonPressed = false;
-                              showSettings();
-                            },
-                          )
-                      ),
-                    ),
-                    new Container(
-                        width: (MediaQuery.of(context).size.width - 120) * 0.5,
-                        child: new FlatButton(
-                          child: new Text("Cancel",
-                            style: TextStyle(color: Color(0xFFD48032), fontSize: 20, fontFamily: 'Roboto', fontWeight: FontWeight.bold, decoration: TextDecoration.underline),
-                            textAlign: TextAlign.center,),
-                          onPressed: () {
-                            _editButtonPressed = false;
-                            clearControllers();
-                            showSettings();
-                          },
-                        )
-                    ),
-                  ]
-              )
-          ]
-        )
-      )
-    );
-  }
-
   Widget buildWaitingScreen() {
     return Scaffold(
       body: Container(
@@ -793,21 +602,6 @@ class _HubScreenState extends State<HubScreen>{
         child: CircularProgressIndicator(),
       ),
     );
-  }
-
-  void updateUser() async {
-    await _firestoreUsers.setUserName(widget.userId, nameController.text == "" ? user.getName() : nameController.text);
-    await _firestoreUsers.setUserEmail(widget.userId, emailController.text == "" ? user.getEmail() : emailController.text);
-    await _firestoreUsers.setUserPhoneNumber(widget.userId, phoneNumberController.text == "" ? user.getPhoneNumber() : phoneNumberController.text);
-    await _firestoreUsers.setUserAddress(widget.userId, addressController.text == "" ? user.getAddress() : addressController.text);
-    clearControllers();
-  }
-
-  void clearControllers() {
-    nameController.clear();
-    emailController.clear();
-    phoneNumberController.clear();
-    addressController.clear();
   }
 
   @override

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -171,7 +171,7 @@ class _SignUpScreenState extends State<SignUpScreen>{
               // showNameInput(),
               // showEmailInput(),
               showPhoneNumberInput(),
-              if (widget.label == 'Medical Facility') showMedicalFacilityNameInput(),
+              if (widget.label == 'Medical Organization') showMedicalFacilityNameInput(),
               if (widget.label == 'Collection Hub') showCollectionHubNameInput(),
               showAddressInput(),
               new SizedBox(height: 24),
@@ -243,7 +243,7 @@ class _SignUpScreenState extends State<SignUpScreen>{
     if (validateAndSave()) {
       try {
         switch(widget.label) {
-          case 'Medical Facility': {
+          case 'Medical Organization': {
             setMedicalFacilityInfo(widget.userId, 
                 _phoneNumber, _medicalFacilityName, _address);
             navigateToRootScreen(context, widget.userId);

--- a/lib/screens/user_type_screen.dart
+++ b/lib/screens/user_type_screen.dart
@@ -56,7 +56,11 @@ class _UserTypeScreenState extends State<UserTypeScreen>{
             shape: new RoundedRectangleBorder(
                 borderRadius: new BorderRadius.circular(10.0)),
             onPressed: () {
-              updateUserType(widget.userId, label);
+              if (label == "Medical Organization") {
+                updateUserType(widget.userId, "Medical Facility");
+              } else {
+                updateUserType(widget.userId, label);
+              }
               Navigator.push(
                 context,
                 MaterialPageRoute(builder: (context) => SignUpScreen(userId: widget.userId, auth: widget.auth, label: label)),

--- a/lib/state_widgets.dart
+++ b/lib/state_widgets.dart
@@ -7,9 +7,10 @@ import 'package:supplyside/util/firestore_users.dart';
 
 class ProfileSettings extends StatefulWidget {
   
-  ProfileSettings({Key key, @required this.user}) : super(key: key);
+  ProfileSettings({Key key, @required this.user, @required this.title}) : super(key: key);
 
   final User user;
+  final String title;
 
   @override
   State<StatefulWidget> createState() => new _ProfileSettingState();
@@ -49,6 +50,11 @@ class _ProfileSettingState extends State<ProfileSettings>{
   }
 
   Widget build(BuildContext context) {
+    String name = widget.user.getName() ?? "";
+    String email = widget.user.getEmail() ?? "";
+    String phoneNo = widget.user.getPhoneNumber() ?? "";
+    String address = widget.user.getAddress() ?? "";
+
     return new Padding (
       padding: EdgeInsets.only(top: 10.0),
       child: Container(
@@ -58,8 +64,11 @@ class _ProfileSettingState extends State<ProfileSettings>{
           mainAxisAlignment: MainAxisAlignment.start,
           children: <Widget>[
             new Row(
-              mainAxisAlignment: MainAxisAlignment.end,
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: <Widget>[
+                new Text(widget.title, style: 
+                  TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold, letterSpacing: 1.5),
+                    textAlign: TextAlign.left,),
                 new IconButton(
                   onPressed: _onEditButtonPressed,
                   icon: Image.asset("assets/images/edit_button.png", height: 26, alignment: Alignment.centerRight),
@@ -79,7 +88,7 @@ class _ProfileSettingState extends State<ProfileSettings>{
                 if (!_editButtonPressed)
                   new Container(
                     width: MediaQuery.of(context).size.width * 0.5,
-                    child: new Text(widget.user.getName(), style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
+                    child: new Text(name, style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
                       textAlign: TextAlign.left,),
                   ),
                 if (_editButtonPressed)
@@ -88,7 +97,7 @@ class _ProfileSettingState extends State<ProfileSettings>{
                       child: new EditFormField(
                         controller: nameController,
                         type: TextInputType.text,
-                        hint: widget.user.getName(),
+                        hint: name,
                         maxLines: 1,
                       )
                   ),
@@ -107,7 +116,7 @@ class _ProfileSettingState extends State<ProfileSettings>{
                   if (!_editButtonPressed)
                     new Container(
                       width: MediaQuery.of(context).size.width * 0.5,
-                      child: new Text(widget.user.getEmail(), style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
+                      child: new Text(email, style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
                         textAlign: TextAlign.left,),
                     ),
                   if (_editButtonPressed)
@@ -116,7 +125,7 @@ class _ProfileSettingState extends State<ProfileSettings>{
                         child: new EditFormField(
                           controller: emailController,
                           type: TextInputType.text,
-                          hint: widget.user.getEmail(),
+                          hint: email,
                           maxLines: 1,
                         )
                     ),
@@ -135,7 +144,7 @@ class _ProfileSettingState extends State<ProfileSettings>{
                   if (!_editButtonPressed)
                     new Container(
                       width: MediaQuery.of(context).size.width * 0.5,
-                      child: new Text(widget.user.getPhoneNumber(), style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
+                      child: new Text(phoneNo, style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
                         textAlign: TextAlign.left,),
                     ),
                   if (_editButtonPressed)
@@ -144,7 +153,7 @@ class _ProfileSettingState extends State<ProfileSettings>{
                         child: new EditFormField(
                           controller: phoneNumberController,
                           type: TextInputType.number,
-                          hint: widget.user.getPhoneNumber(),
+                          hint: phoneNo,
                           formatter: <TextInputFormatter>[
                             WhitelistingTextInputFormatter.digitsOnly
                           ],
@@ -166,7 +175,7 @@ class _ProfileSettingState extends State<ProfileSettings>{
                   if (!_editButtonPressed)
                     new Container(
                       width: MediaQuery.of(context).size.width * 0.5,
-                      child: new Text(widget.user.getAddress(), style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
+                      child: new Text(address, style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
                         textAlign: TextAlign.left,),
                     ),
                   if (_editButtonPressed)
@@ -175,7 +184,7 @@ class _ProfileSettingState extends State<ProfileSettings>{
                       child: new EditFormField(
                         controller: addressController,
                         type: TextInputType.text,
-                        hint: widget.user.getAddress(),
+                        hint: address,
                         maxLines: 1,
                       )
                     ),

--- a/lib/state_widgets.dart
+++ b/lib/state_widgets.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:supplyside/locator.dart';
+import 'package:supplyside/widgets.dart';
+import 'package:supplyside/datamodels/user.dart';
+import 'package:supplyside/util/firestore_users.dart';
+
+class ProfileSettings extends StatefulWidget {
+  
+  ProfileSettings({Key key, @required this.user}) : super(key: key);
+
+  final User user;
+
+  @override
+  State<StatefulWidget> createState() => new _ProfileSettingState();
+}
+
+class _ProfileSettingState extends State<ProfileSettings>{
+  final FirestoreUsers _firestoreUsers = locator<FirestoreUsers>();
+  bool _editButtonPressed = false;
+  TextEditingController nameController = TextEditingController();
+  TextEditingController emailController = TextEditingController();
+  TextEditingController phoneNumberController = TextEditingController();
+  TextEditingController addressController = TextEditingController();
+
+  void _onEditButtonPressed() {
+    _editButtonPressed = !_editButtonPressed;
+    clearControllers();
+    build(context);
+  }
+
+  void clearControllers() {
+    nameController.clear();
+    emailController.clear();
+    phoneNumberController.clear();
+    addressController.clear();
+  }
+
+  void updateUser() async {
+    await _firestoreUsers.setUserName(widget.user.id, nameController.text == "" ? 
+      widget.user.getName() : nameController.text);
+    await _firestoreUsers.setUserEmail(widget.user.id, emailController.text == "" ? 
+      widget.user.getEmail() : emailController.text);
+    await _firestoreUsers.setUserPhoneNumber(widget.user.id, phoneNumberController.text == "" ?
+      widget.user.getPhoneNumber() : phoneNumberController.text);
+    await _firestoreUsers.setUserAddress(widget.user.id, addressController.text == "" ? 
+      widget.user.getAddress() : addressController.text);
+    clearControllers();
+  }
+
+  Widget build(BuildContext context) {
+    return new Padding (
+      padding: EdgeInsets.only(top: 10.0),
+      child: Container(
+        width: MediaQuery.of(context).size.width - 100,
+        child: new Column (
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: <Widget>[
+            new Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: <Widget>[
+                new IconButton(
+                  onPressed: _onEditButtonPressed,
+                  icon: Image.asset("assets/images/edit_button.png", height: 26, alignment: Alignment.centerRight),
+                )
+              ]
+            ),
+            SizedBox(height: 5),
+            new Row(
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: <Widget>[
+                new Container(
+                  width: MediaQuery.of(context).size.width * 0.25,
+                  child: new Text("Name", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.left,)
+                ),
+                if (!_editButtonPressed)
+                  new Container(
+                    width: MediaQuery.of(context).size.width * 0.5,
+                    child: new Text(widget.user.getName(), style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
+                      textAlign: TextAlign.left,),
+                  ),
+                if (_editButtonPressed)
+                  new Container(
+                      width: MediaQuery.of(context).size.width * 0.5,
+                      child: new EditFormField(
+                        controller: nameController,
+                        type: TextInputType.text,
+                        hint: widget.user.getName(),
+                        maxLines: 1,
+                      )
+                  ),
+              ]
+            ),
+            SizedBox(height: 10),
+            new Row(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: <Widget>[
+                  new Container(
+                      width: MediaQuery.of(context).size.width * 0.25,
+                      child: new Text("Email", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+                        textAlign: TextAlign.left,)
+                  ),
+                  if (!_editButtonPressed)
+                    new Container(
+                      width: MediaQuery.of(context).size.width * 0.5,
+                      child: new Text(widget.user.getEmail(), style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
+                        textAlign: TextAlign.left,),
+                    ),
+                  if (_editButtonPressed)
+                    new Container(
+                        width: MediaQuery.of(context).size.width * 0.5,
+                        child: new EditFormField(
+                          controller: emailController,
+                          type: TextInputType.text,
+                          hint: widget.user.getEmail(),
+                          maxLines: 1,
+                        )
+                    ),
+                ]
+            ),
+            SizedBox(height: 10),
+            new Row(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: <Widget>[
+                  new Container(
+                      width: MediaQuery.of(context).size.width * 0.25,
+                      child: new Text("Phone", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+                        textAlign: TextAlign.left,)
+                  ),
+                  if (!_editButtonPressed)
+                    new Container(
+                      width: MediaQuery.of(context).size.width * 0.5,
+                      child: new Text(widget.user.getPhoneNumber(), style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
+                        textAlign: TextAlign.left,),
+                    ),
+                  if (_editButtonPressed)
+                    new Container(
+                        width: MediaQuery.of(context).size.width * 0.5,
+                        child: new EditFormField(
+                          controller: phoneNumberController,
+                          type: TextInputType.number,
+                          hint: widget.user.getPhoneNumber(),
+                          formatter: <TextInputFormatter>[
+                            WhitelistingTextInputFormatter.digitsOnly
+                          ],
+                          maxLines: 1,
+                        )
+                    ),
+                ]
+            ),
+            SizedBox(height: 10),
+            new Row(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: <Widget>[
+                  new Container(
+                      width: MediaQuery.of(context).size.width * 0.25,
+                      child: new Text("Address", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+                        textAlign: TextAlign.left,)
+                  ),
+                  if (!_editButtonPressed)
+                    new Container(
+                      width: MediaQuery.of(context).size.width * 0.5,
+                      child: new Text(widget.user.getAddress(), style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
+                        textAlign: TextAlign.left,),
+                    ),
+                  if (_editButtonPressed)
+                    new Container(
+                        width: MediaQuery.of(context).size.width * 0.5,
+                      child: new EditFormField(
+                        controller: addressController,
+                        type: TextInputType.text,
+                        hint: widget.user.getAddress(),
+                        maxLines: 1,
+                      )
+                    ),
+                ]
+            ),
+            SizedBox(height: 20),
+            if (_editButtonPressed)
+              new Row (
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    new Padding (
+                      padding: EdgeInsets.only(right: 4),
+                      child: new Container(
+                          width: (MediaQuery.of(context).size.width - 120) * 0.5,
+                          child: new FlatButton(
+                            child: new Text("Save",
+                              style: TextStyle(color: Color(0xFF283568), fontSize: 20, fontFamily: 'Roboto', fontWeight: FontWeight.bold, decoration: TextDecoration.underline),
+                              textAlign: TextAlign.center,),
+                            onPressed: () {
+                              updateUser();
+                              _editButtonPressed = false;
+                              build(context);
+                            },
+                          )
+                      ),
+                    ),
+                    new Container(
+                        width: (MediaQuery.of(context).size.width - 120) * 0.5,
+                        child: new FlatButton(
+                          child: new Text("Cancel",
+                            style: TextStyle(color: Color(0xFFD48032), fontSize: 20, fontFamily: 'Roboto', fontWeight: FontWeight.bold, decoration: TextDecoration.underline),
+                            textAlign: TextAlign.center,),
+                          onPressed: () {
+                            _editButtonPressed = false;
+                            clearControllers();
+                            build(context);
+                          },
+                        )
+                    ),
+                  ]
+              )
+          ]
+        )
+      )
+    );
+  }
+}

--- a/lib/util/mock_consts.dart
+++ b/lib/util/mock_consts.dart
@@ -1,7 +1,7 @@
 import 'package:supplyside/datamodels/item.dart';
 import 'package:supplyside/datamodels/order.dart';
 
-String faceShildImg = 'https://s3-us-west-2.amazonaws.com/issuewireassets/primg/27694/thumb_first-nih-recommended-3d-printed-face-shield-for-covid-19-launched-by-design-that-matter60.jpg';
+String faceShildImg = "assets/images/face_shield_icon.png";
 String aBoxImg = 'https://matchgrademed.com/wp-content/uploads/2020/04/Stackable-Aerosol-Box.jpg';
 Item faceShield = Item('Face Shield', faceShildImg, 'To protect your face', [ItemRequirement.fabricator]);
 Item aerosolBox = Item('Aersol Box', aBoxImg, 'Prevent pathogens in the air', [ItemRequirement.laserCutter]);

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -257,6 +257,29 @@ class NewOrderButton extends StatelessWidget {
   }
 }
 
+class NewOrderPlus extends StatelessWidget {
+  final Function() onPressed;
+
+  NewOrderPlus ({Key key, @required this.onPressed}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.transparent,
+      padding: EdgeInsets.only(top: 8, left: 40),
+      alignment: Alignment.centerLeft,
+      child: Container(
+          child: new FlatButton.icon(
+            icon: Icon(Icons.add_circle, color: Color(0XFFB7CDFF), size: 48.0), 
+            label: new Text("   Add Order",
+              style: TextStyle(color: Colors.black, fontSize: 24, fontFamily: 'Roboto',),
+              textAlign: TextAlign.left,),
+            onPressed: onPressed,
+          )
+      ),
+    );
+  }
+}
+
 
 class ItemCard extends StatelessWidget {
   final String asset;

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:supplyside/util/authentication.dart';
 
 class BayShieldAppBar extends StatelessWidget {
   final String title;

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -231,6 +231,32 @@ class InventoryButton extends StatelessWidget {
   }
 }
 
+class NewOrderButton extends StatelessWidget {
+  final Function() onPressed;
+
+  NewOrderButton ({Key key, @required this.onPressed}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: MediaQuery.of(context).size.height / 12,
+      width: MediaQuery.of(context).size.width - 110,
+      color: Colors.transparent,
+      child: Container(
+          decoration: BoxDecoration(
+              color: Color(0xFF283568),
+              borderRadius: BorderRadius.all(Radius.circular(10.0))),
+          child: new FlatButton(
+            child: new Text("New Order",
+              style: TextStyle(color: Colors.white, fontSize: 24, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,),
+            onPressed: onPressed,
+          )
+      ),
+    );
+  }
+}
+
+
 class ItemCard extends StatelessWidget {
   final String asset;
   final String itemName;

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -583,3 +583,36 @@ class EditFormField extends StatelessWidget {
     );
   }
 }
+
+class TwoToggle extends StatelessWidget {
+  final Function(int) onPressed;
+  final List<bool> isSelected;
+  final String left;
+  final String right;
+
+  TwoToggle({Key key, @required this.onPressed, @required this.isSelected,
+    @required this.left, @required this.right,}) : super(key: key);
+
+  Widget build(BuildContext context) {
+    return new Container(
+      decoration: BoxDecoration(
+      borderRadius: BorderRadius.circular(10),
+        color: Color(0xFFD2D2D2),
+      ),
+        child: ToggleButtons(
+      fillColor: Color(0xFFB7CDFF),
+      borderWidth: 0.0,
+      constraints: BoxConstraints(minWidth: (MediaQuery.of(context).size.width - 110)/2, minHeight: MediaQuery.of(context).size.height / 25),
+      borderRadius: BorderRadius.all(Radius.circular(10.0)),
+      children: <Widget>[
+        new Text(left, style: TextStyle(color: Colors.black, fontSize: 13, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+          textAlign: TextAlign.center,),
+        new Text(right, style: TextStyle(color: Colors.black, fontSize: 13, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+          textAlign: TextAlign.center,),
+      ],
+      onPressed: onPressed,
+      isSelected: isSelected,
+    ),
+    );
+  }
+}

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -630,9 +630,9 @@ class TwoToggle extends StatelessWidget {
       constraints: BoxConstraints(minWidth: (MediaQuery.of(context).size.width - 110)/2, minHeight: MediaQuery.of(context).size.height / 25),
       borderRadius: BorderRadius.all(Radius.circular(10.0)),
       children: <Widget>[
-        new Text(left, style: TextStyle(color: Colors.black, fontSize: 13, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+        new Text(left, style: TextStyle(color: Colors.black, fontSize: 15, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
           textAlign: TextAlign.center,),
-        new Text(right, style: TextStyle(color: Colors.black, fontSize: 13, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+        new Text(right, style: TextStyle(color: Colors.black, fontSize: 15, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
           textAlign: TextAlign.center,),
       ],
       onPressed: onPressed,

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -61,7 +61,8 @@ class UserTypeTag extends StatelessWidget {
             borderRadius: BorderRadius.all(Radius.circular(5.0))),
         child: new Center(
           child: new Text(userTag,
-            style: TextStyle(color: Colors.black, fontSize: 15, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+            style: TextStyle(color: Colors.black, fontSize: 15, fontFamily: 'Roboto', 
+            fontWeight: FontWeight.bold, letterSpacing: 2.0),
             textAlign: TextAlign.center,),
         )
       )
@@ -84,7 +85,8 @@ class UserTypeTagBlue extends StatelessWidget {
             color: Color(0xFF697CC8), 
             borderRadius: BorderRadius.all(Radius.circular(5.0))),
             child: new Text(userTag.toUpperCase(),
-              style: TextStyle(color: Colors.white, fontSize: 15, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+              style: TextStyle(color: Colors.white, fontSize: 15, 
+              fontFamily: 'Roboto', fontWeight: FontWeight.bold, letterSpacing: 2.0),
               textAlign: TextAlign.center,),
       )
     );


### PR DESCRIPTION
> Overview: creating and using widget components from new UI from hub screen to consumer screen (medorgs)

**Demo**
![Screen Shot 2020-06-14 at 2 41 46 PM](https://user-images.githubusercontent.com/25168261/84604811-942e5280-ae4d-11ea-863a-6558b50c61a1.png)
![Screen Shot 2020-06-14 at 2 41 39 PM](https://user-images.githubusercontent.com/25168261/84604816-955f7f80-ae4d-11ea-9134-25a97d46efbe.png)
![Screen Shot 2020-06-14 at 2 41 56 PM](https://user-images.githubusercontent.com/25168261/84604818-97c1d980-ae4d-11ea-84e7-1bc2bab72230.png)


**Edited screens:**
-  `hub_screen`: exchanged code to be reused into `widgets/state_widgets.dart`
- `consumer_screen` create three-page UI based on `hub_screen` components, deleted old irrelevant components 
- `user_type_screen.dart`, `signup_screen`: to reflect name change from medical facility to orgs
- 'widgets.dart': TwoToggle for settings, letter spacing to tags, order buttons for medorgs

**New screens:**
- `state_widgets.dart`: a new dart widget library for stateful widgets that are not full screens (added ProfileSettings  widgets with its own firestore interactions)

**Edited data models:**
- User: added phoneNumber to Medical Facility user type