### PR TITLE
Medical Organization Status Fields

### DIFF
--- a/lib/datamodels/user.dart
+++ b/lib/datamodels/user.dart
@@ -51,7 +51,8 @@ class User {
 
 class MedicalFacility extends User {
 
-  MedicalFacility({id, String email, String phoneNumber, this.address, @required this.medicalFacilityName, this.staffSize}) :
+  MedicalFacility({id, String email, String phoneNumber, 
+  this.address, @required this.medicalFacilityName, int staff, int cases, List<int> supply}) :
     super(
       id: id, 
       email: email, 
@@ -65,10 +66,29 @@ class MedicalFacility extends User {
       name = data['name'],
       address = data['address'],
       phoneNumber = data['phoneNumber'],
-      medicalFacilityName = data['medicalFacilityName'];
+      medicalFacilityName = data['medicalFacilityName'],
+      staff = data["staff"],
+      cases = data["cases"],
+      shieldSupply = data["shieldSupply"],
+      gownSupply = data["gownSupply"],
+      gloveSupply = data["gloveSupply"],
+      maskSupply = data["maskSupply"]
+      ;
 
   String getFacilityName() {
     return this.medicalFacilityName;
+  }
+
+  int getStaff() {
+    return this.staff;
+  }
+
+  int getCases() {
+    return this.cases;
+  }
+
+  List<int> getSupply() {
+    return [shieldSupply ?? 0, gownSupply ?? 0, gloveSupply ?? 0, maskSupply ?? 0];
   }
 
   String id;
@@ -76,7 +96,12 @@ class MedicalFacility extends User {
   String name;
   String address;
   String medicalFacilityName;
-  int staffSize;
+  int shieldSupply;
+  int gownSupply;
+  int gloveSupply;
+  int maskSupply;
+  int staff;
+  int cases;
   String contactPersonName;
   String contactPersonTitle;
   String phoneNumber;

--- a/lib/screens/med_org_screen.dart
+++ b/lib/screens/med_org_screen.dart
@@ -294,8 +294,7 @@ class _MedicalOrganizationScreenState extends State<MedicalOrganizationScreen> {
                           },
                           isSelected: _isSelectedProfilePage,
                         ),
-                        if (_displayStatus) new Text("TODO: Organization Details", style: TextStyle(color: Colors.black, fontSize: 25, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
-                          textAlign: TextAlign.left,),
+                        if (_displayStatus) new MedorgsStatus(user: user),
                         if (_displaySettings) new ProfileSettings(user: user, title: "Personal Information"),
                       ]
                   )

--- a/lib/state_widgets.dart
+++ b/lib/state_widgets.dart
@@ -313,7 +313,7 @@ class _MedorgsStatusState extends State<MedorgsStatus>{
               children: <Widget>[
                 new Container(
                   width: MediaQuery.of(context).size.width * 0.5,
-                  child: new Text("Number of Personell", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+                  child: new Text("Number of Personnel", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
                     textAlign: TextAlign.left,)
                 ),
                 if (!_editButtonPressed)

--- a/lib/state_widgets.dart
+++ b/lib/state_widgets.dart
@@ -232,3 +232,299 @@ class _ProfileSettingState extends State<ProfileSettings>{
     );
   }
 }
+
+class MedorgsStatus extends StatefulWidget {
+  
+  MedorgsStatus({Key key, @required this.user}) : super(key: key);
+
+  final MedicalFacility user;
+
+  @override
+  State<StatefulWidget> createState() => new _MedorgsStatusState();
+}
+
+class _MedorgsStatusState extends State<MedorgsStatus>{
+  final FirestoreUsers _firestoreUsers = locator<FirestoreUsers>();
+  bool _editButtonPressed = false;
+  TextEditingController staffController = TextEditingController();
+  TextEditingController casesController = TextEditingController();
+  // Under Supply
+  TextEditingController shieldSupplyController = TextEditingController();
+  TextEditingController gownSupplyController = TextEditingController();
+  TextEditingController gloveSupplyController = TextEditingController();
+  TextEditingController maskSupplyController = TextEditingController();
+
+  void _onEditButtonPressed() {
+    _editButtonPressed = !_editButtonPressed;
+    clearControllers();
+    build(context);
+  }
+
+  void clearControllers() {
+    staffController.clear();
+    casesController.clear();
+    shieldSupplyController.clear();
+    gownSupplyController.clear();
+    gloveSupplyController.clear();
+    maskSupplyController.clear(); 
+  }
+
+  void updateUser() async {
+    await _firestoreUsers.setOrgDetails(widget.user.id,
+      int.parse(staffController.text), 
+      int.parse(casesController.text),
+      int.parse(shieldSupplyController.text),
+      int.parse(gownSupplyController.text),
+      int.parse(gloveSupplyController.text),
+      int.parse(maskSupplyController.text)
+      );
+    clearControllers();
+  }
+
+  Widget build(BuildContext context) {
+    int staff = widget.user.getStaff() ?? 0;
+    int cases = widget.user.getCases() ?? 0;
+    var supply = widget.user.getSupply() ?? [0, 0, 0, 0];
+
+    return new Padding (
+      padding: EdgeInsets.only(top: 10.0),
+      child: Container(
+        width: MediaQuery.of(context).size.width - 100,
+        child: new Column (
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: <Widget>[
+            new Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                new Text("Organization Details", style: 
+                  TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold, letterSpacing: 1.5),
+                    textAlign: TextAlign.left,),
+                new IconButton(
+                  onPressed: _onEditButtonPressed,
+                  icon: Image.asset("assets/images/edit_button.png", height: 26, alignment: Alignment.centerRight),
+                )
+              ]
+            ),
+            SizedBox(height: 5),
+            new Row(
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: <Widget>[
+                new Container(
+                  width: MediaQuery.of(context).size.width * 0.5,
+                  child: new Text("Number of Personell", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.left,)
+                ),
+                if (!_editButtonPressed)
+                  new Container(
+                    width: MediaQuery.of(context).size.width * 0.25,
+                    child: new Text(staff.toString(), style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
+                      textAlign: TextAlign.left,),
+                  ),
+                if (_editButtonPressed)
+                  new Container(
+                      width: MediaQuery.of(context).size.width * 0.25,
+                      child: new EditFormField(
+                        controller: staffController,
+                        type: TextInputType.number,
+                        hint: staff.toString(),
+                        maxLines: 1,
+                      )
+                  ),
+              ]
+            ),
+            SizedBox(height: 10),
+            new Row(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: <Widget>[
+                  new Container(
+                      width: MediaQuery.of(context).size.width * 0.5,
+                      child: new Text("Reported Cases", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+                        textAlign: TextAlign.left,)
+                  ),
+                  if (!_editButtonPressed)
+                    new Container(
+                      width: MediaQuery.of(context).size.width * 0.25,
+                      child: new Text(cases.toString(), style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto'),
+                        textAlign: TextAlign.left,),
+                    ),
+                  if (_editButtonPressed)
+                    new Container(
+                        width: MediaQuery.of(context).size.width * 0.25,
+                        child: new EditFormField(
+                          controller: casesController,
+                          type: TextInputType.text,
+                          hint: cases.toString(),
+                          maxLines: 1,
+                        )
+                    ),
+                ]
+            ),
+            SizedBox(height: 10),
+            new Row(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: <Widget>[
+                  new Container(
+                      width: MediaQuery.of(context).size.width * 0.5,
+                      child: new Text("Current Supply", style: TextStyle(color: Colors.black, fontSize: 18, fontFamily: 'Roboto', fontWeight: FontWeight.bold),
+                        textAlign: TextAlign.left,)
+                  ),
+                ]
+            ),
+            SizedBox(height: 10),
+            new Container(margin: new EdgeInsets.only(left: 16.0),
+              child: new Column (children: <Widget>[
+                  new Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: <Widget>[
+                      new Container(
+                          width: MediaQuery.of(context).size.width * 0.45,
+                          child: new Text("Face Shields", style: TextStyle(color: Colors.black, fontSize: 15, fontFamily: 'Roboto'),
+                            textAlign: TextAlign.left,)
+                      ),
+                      if (!_editButtonPressed)
+                        new Container(
+                          width: MediaQuery.of(context).size.width * 0.25,
+                          child: new Text(supply[0].toString(), style: TextStyle(color: Colors.black, fontSize: 15, fontFamily: 'Roboto'),
+                            textAlign: TextAlign.left,),
+                        ),
+                      if (_editButtonPressed)
+                        new Container(
+                            width: MediaQuery.of(context).size.width * 0.25,
+                          child: new EditFormField(
+                            controller: shieldSupplyController,
+                            type: TextInputType.text,
+                            hint: supply[0].toString(),
+                            maxLines: 1,
+                          )
+                        ),
+                    ]
+                ),
+                new Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: <Widget>[
+                      new Container(
+                          width: MediaQuery.of(context).size.width * 0.45,
+                          child: new Text("Gowns", style: TextStyle(color: Colors.black, fontSize: 15, fontFamily: 'Roboto'),
+                            textAlign: TextAlign.left,)
+                      ),
+                      if (!_editButtonPressed)
+                        new Container(
+                          width: MediaQuery.of(context).size.width * 0.25,
+                          child: new Text(supply[1].toString(), style: TextStyle(color: Colors.black, fontSize: 15, fontFamily: 'Roboto'),
+                            textAlign: TextAlign.left,),
+                        ),
+                      if (_editButtonPressed)
+                        new Container(
+                            width: MediaQuery.of(context).size.width * 0.25,
+                          child: new EditFormField(
+                            controller: gownSupplyController,
+                            type: TextInputType.text,
+                            hint: supply[1].toString(),
+                            maxLines: 1,
+                          )
+                        ),
+                    ]
+                ),
+                new Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: <Widget>[
+                      new Container(
+                          width: MediaQuery.of(context).size.width * 0.45,
+                          child: new Text("Gloves", style: TextStyle(color: Colors.black, fontSize: 15, fontFamily: 'Roboto'),
+                            textAlign: TextAlign.left,)
+                      ),
+                      if (!_editButtonPressed)
+                        new Container(
+                          width: MediaQuery.of(context).size.width * 0.25,
+                          child: new Text(supply[2].toString(), style: TextStyle(color: Colors.black, fontSize: 15, fontFamily: 'Roboto'),
+                            textAlign: TextAlign.left,),
+                        ),
+                      if (_editButtonPressed)
+                        new Container(
+                            width: MediaQuery.of(context).size.width * 0.25,
+                          child: new EditFormField(
+                            controller: gloveSupplyController,
+                            type: TextInputType.text,
+                            hint: supply[2].toString(),
+                            maxLines: 1,
+                          )
+                        ),
+                    ]
+                ),
+                new Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: <Widget>[
+                      new Container(
+                          width: MediaQuery.of(context).size.width * 0.45,
+                          child: new Text("Masks", style: TextStyle(color: Colors.black, fontSize: 15, fontFamily: 'Roboto'),
+                            textAlign: TextAlign.left,)
+                      ),
+                      if (!_editButtonPressed)
+                        new Container(
+                          width: MediaQuery.of(context).size.width * 0.25,
+                          child: new Text(supply[3].toString(), style: TextStyle(color: Colors.black, fontSize: 15, fontFamily: 'Roboto'),
+                            textAlign: TextAlign.left,),
+                        ),
+                      if (_editButtonPressed)
+                        new Container(
+                            width: MediaQuery.of(context).size.width * 0.25,
+                          child: new EditFormField(
+                            controller: maskSupplyController,
+                            type: TextInputType.text,
+                            hint: supply[3].toString(),
+                            maxLines: 1,
+                          )
+                        ),
+                    ]
+                ),
+            ])),
+            SizedBox(height: 20),
+            if (_editButtonPressed)
+              new Row (
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    new Padding (
+                      padding: EdgeInsets.only(right: 4),
+                      child: new Container(
+                          width: (MediaQuery.of(context).size.width - 120) * 0.5,
+                          child: new FlatButton(
+                            child: new Text("Save",
+                              style: TextStyle(color: Color(0xFF283568), fontSize: 20, fontFamily: 'Roboto', fontWeight: FontWeight.bold, decoration: TextDecoration.underline),
+                              textAlign: TextAlign.center,),
+                            onPressed: () {
+                              updateUser();
+                              _editButtonPressed = false;
+                              build(context);
+                            },
+                          )
+                      ),
+                    ),
+                    new Container(
+                        width: (MediaQuery.of(context).size.width - 120) * 0.5,
+                        child: new FlatButton(
+                          child: new Text("Cancel",
+                            style: TextStyle(color: Color(0xFFD48032), fontSize: 20, fontFamily: 'Roboto', fontWeight: FontWeight.bold, decoration: TextDecoration.underline),
+                            textAlign: TextAlign.center,),
+                          onPressed: () {
+                            _editButtonPressed = false;
+                            clearControllers();
+                            build(context);
+                          },
+                        )
+                    ),
+                  ]
+              )
+          ]
+        )
+      )
+    );
+  }
+}

--- a/lib/util/firestore_users.dart
+++ b/lib/util/firestore_users.dart
@@ -96,4 +96,36 @@ class FirestoreUsers {
       return e.message;
     }
   }
+
+  Future setOrgDetails(String id, int staff, int cases, 
+  int shieldSupply, int gownSupply, int gloveSupply, int maskSupply) async {
+    try {
+      if (staff != null && staff >= 0) {
+        await _usersCollectionReference.document(id).updateData({"staff": staff});
+        print('Saved new staff number: $staff');
+      }
+      if (cases != null && cases >= 0) {
+        await _usersCollectionReference.document(id).updateData({"cases": cases});
+        print('Saved new reported case number: $cases');
+      }
+      if (shieldSupply != null && shieldSupply >= 0) {
+        await _usersCollectionReference.document(id).updateData({"shieldSupply": shieldSupply});
+        print('Saved new shield supply number: $shieldSupply');
+      }
+      if (gownSupply != null && gownSupply >= 0) {
+        await _usersCollectionReference.document(id).updateData({"gownSupply": gownSupply});
+        print('Saved new gown supply number: $gownSupply');
+      }
+      if (gloveSupply != null && gloveSupply >= 0) {
+        await _usersCollectionReference.document(id).updateData({"gloveSupply": gloveSupply});
+        print('Saved new glove supply number: $gloveSupply');
+      }
+      if (maskSupply != null && maskSupply >= 0) {
+        await _usersCollectionReference.document(id).updateData({"maskSupply": maskSupply});
+        print('Saved new mask supply number: $maskSupply');
+      }
+    } catch (e) {
+      return e.message;
+    }
+  }
 }


### PR DESCRIPTION
> Overview: UI and backend integration with new fields for medical organizations to help with priority algorithms

**Demo**
![Screen Shot 2020-06-17 at 1 12 26 PM](https://user-images.githubusercontent.com/25168261/84945935-c2ee3800-b09c-11ea-8e2e-ce31efd8dfab.png)
![Screen Shot 2020-06-17 at 1 12 38 PM](https://user-images.githubusercontent.com/25168261/84945941-c41f6500-b09c-11ea-8b0c-18100771019c.png)
<img width="358" alt="Screen Shot 2020-06-17 at 1 13 29 PM" src="https://user-images.githubusercontent.com/25168261/84945951-c7b2ec00-b09c-11ea-9b34-76411d67c0d0.png">

**Edited Screens**
- `user.dart` add new fields for Medical Facility (user subtype) to include supply counts, staff size and number of reported cases
- `state_widgets.dart` add new `MedorgDetails` stateful widget similar to `ProfileSettings` with UI fields and controllers, calling firestore on submit of changes (default number to 0, changes fields only when inputs of valid integers >= 0)
- `firestore_users.dart` add functionality to create new fields for medical facility users (following six: `staff, cases, shieldSupply, gloveSupply, gownSupply, maskSupply`)


