### PR TITLE
Implement inventory backend 

### DIFF
--- a/lib/datamodels/user.dart
+++ b/lib/datamodels/user.dart
@@ -1,5 +1,3 @@
-
-
 import 'package:flutter/cupertino.dart';
 
 class User {
@@ -10,6 +8,7 @@ class User {
   String name;
   String address;
   String phoneNumber;
+
   User({this.id, this.email, this.type});
 
   User.fromData(Map<String, dynamic> data)
@@ -19,7 +18,7 @@ class User {
       name = data['name'],
       address = data['address'],
       phoneNumber = data['phoneNumber'];
-      
+
   Map<String, dynamic> toJson() {
     return {
       'id': id,
@@ -106,4 +105,85 @@ class MedicalFacility extends User {
   String contactPersonTitle;
   String phoneNumber;
 
+}
+
+class CollectionHub extends User {
+
+  String id;
+  String email;
+  String name;
+  String address;
+  String phoneNumber;
+  String collectionHubName;
+
+  CollectionHub({id, String email, String phoneNumber,
+    this.address, @required this.collectionHubName}) :
+        super(
+          id: id,
+          email: email,
+          type: "Collection Hub"
+      );
+
+  @override
+  CollectionHub.fromData(Map<String, dynamic> data)
+      : id = data['id'],
+        email = data['email'],
+        name = data['name'],
+        address = data['address'],
+        phoneNumber = data['phoneNumber'],
+        collectionHubName = data['collectionHubName'],
+        faceShieldUCSFA1Supply = data['Face Shield'] == null ? 0 : data['Face Shield']['UCSF A1'] ?? 0,
+        faceShieldUCSFC1Supply = data['Face Shield'] == null ? 0 : data['Face Shield']['UCSF C1'] ?? 0,
+        maskClothSupply = data['Mask'] == null ? 0 : data['Mask']['Cloth'] ?? 0,
+        maskN95Supply = data['Mask'] == null ? 0 : data['Mask']['N95'] ?? 0,
+        maskSurgicalSupply = data['Mask'] == null ? 0 : data['Mask']['Surgical'] ?? 0,
+        glovesSurgicalSupply = data['Gloves'] == null ? 0 : data['Gloves']['Surgical'] ?? 0,
+        glovesNitrileSupply = data['Gloves'] == null ? 0 : data['Gloves']['Nitrile'] ?? 0,
+        glovesNeopreneSupply = data['Gloves'] == null ? 0 : data['Gloves']['Neoprene'] ?? 0,
+        gogglesSurgicalSupply = data['Goggles'] == null ? 0 : data['Goggles']['Surgical'] ?? 0,
+        gownRegularSupply = data['Gown'] == null ? 0 : data['Gown']['Regular'] ?? 0,
+        handSanitizerRegularSupply = data['Hand Sanitizer'] == null ? 0 : data['Hand Sanitizer']['Regular'] ?? 0;
+
+  String getFacilityName() {
+    return this.collectionHubName;
+  }
+
+  int getSupply(String itemName, String itemType) {
+    switch (itemName + " " + itemType) {
+      case "Face Shield UCSF A1":
+        return this.faceShieldUCSFA1Supply;
+      case "Face Shield UCSF C1":
+        return this.faceShieldUCSFC1Supply;
+      case "Mask Cloth":
+        return this.maskClothSupply;
+      case "Mask N95":
+        return this.maskN95Supply;
+      case "Mask Surgical":
+        return this.maskSurgicalSupply;
+      case "Gloves Surgical":
+        return this.glovesSurgicalSupply;
+      case "Gloves Nitrile":
+        return this.glovesNitrileSupply;
+      case "Gloves Neoprene":
+        return this.glovesNeopreneSupply;
+      case "Goggles Surgical":
+        return this.gogglesSurgicalSupply;
+      case "Gown Regular":
+        return this.gownRegularSupply;
+      case "Hand Sanitizer Regular":
+        return this.handSanitizerRegularSupply;
+    }
+  }
+
+  int faceShieldUCSFA1Supply;
+  int faceShieldUCSFC1Supply;
+  int maskClothSupply;
+  int maskN95Supply;
+  int maskSurgicalSupply;
+  int glovesSurgicalSupply;
+  int glovesNitrileSupply;
+  int glovesNeopreneSupply;
+  int gogglesSurgicalSupply;
+  int gownRegularSupply;
+  int handSanitizerRegularSupply;
 }

--- a/lib/state_widgets.dart
+++ b/lib/state_widgets.dart
@@ -528,3 +528,265 @@ class _MedorgsStatusState extends State<MedorgsStatus>{
     );
   }
 }
+
+class InventoryPage extends StatefulWidget {
+  InventoryPage({Key key, @required this.user}) : super(key: key);
+
+  final CollectionHub user;
+
+  @override
+  State<StatefulWidget> createState() => new _InventoryPageState();
+}
+
+class _InventoryPageState extends State<InventoryPage> {
+
+  final FirestoreUsers _firestoreUsers = locator<FirestoreUsers>();
+
+  bool _inventoryEditButtonPressed = false;
+
+  int faceShieldUCSFA1;
+  int faceShieldUCSFC1;
+  int maskCloth;
+  int maskN95;
+  int maskSurgical;
+  int glovesSurgical;
+  int glovesNitrile;
+  int glovesNeoprene;
+  int gogglesSurgical;
+  int gown;
+  int handSanitizer;
+
+  TextEditingController faceShieldController1 = TextEditingController();
+  TextEditingController faceShieldController2 = TextEditingController();
+  TextEditingController maskController1 = TextEditingController();
+  TextEditingController maskController2 = TextEditingController();
+  TextEditingController maskController3 = TextEditingController();
+  TextEditingController glovesController1 = TextEditingController();
+  TextEditingController glovesController2 = TextEditingController();
+  TextEditingController glovesController3 = TextEditingController();
+  TextEditingController gogglesController = TextEditingController();
+  TextEditingController gownController = TextEditingController();
+  TextEditingController handSanitizerController = TextEditingController();
+
+  void _onInventoryEditButtonPressed() {
+    _inventoryEditButtonPressed = !_inventoryEditButtonPressed;
+    clearControllers();
+    build(context);
+  }
+
+  void clearControllers() {
+    faceShieldController1.clear();
+    faceShieldController2.clear();
+    maskController1.clear();
+    maskController2.clear();
+    maskController3.clear();
+    glovesController1.clear();
+    glovesController2.clear();
+    glovesController3.clear();
+    gogglesController.clear();
+    gownController.clear();
+    handSanitizerController.clear();
+  }
+
+  Widget showInventoryCards(bool edit) {
+
+    List<Widget> list = new List<Widget>();
+
+    faceShieldUCSFA1 = widget.user.getSupply("Face Shield", "UCSF A1") ?? 0;
+    faceShieldUCSFC1 = widget.user.getSupply("Face Shield", "UCSF C1") ?? 0;
+    maskCloth = widget.user.getSupply("Mask", "Cloth") ?? 0;
+    maskN95 = widget.user.getSupply("Mask", "N95") ?? 0;
+    maskSurgical = widget.user.getSupply("Mask", "Surgical") ?? 0;
+    glovesSurgical = widget.user.getSupply("Gloves", "Surgical") ?? 0;
+    glovesNitrile = widget.user.getSupply("Gloves", "Nitrile") ?? 0;
+    glovesNeoprene = widget.user.getSupply("Gloves", "Neoprene") ?? 0;
+    gogglesSurgical = widget.user.getSupply("Goggles", "Surgical") ?? 0;
+    gown = widget.user.getSupply("Gown", "Regular") ?? 0;
+    handSanitizer = widget.user.getSupply("Hand Sanitizer", "Regular") ?? 0;
+
+    if (faceShieldUCSFA1 > 0) {
+      if (edit) {
+        list.add(InventoryEditCard(asset: "assets/images/face_shield_card.png",
+            itemName: "Face Shield", quantity: faceShieldUCSFA1, itemType: "UCSF A1", controller: faceShieldController1));
+      } else {
+        list.add(InventoryCard(asset: "assets/images/face_shield_card.png",
+            itemName: "Face Shield", quantity: faceShieldUCSFA1, itemType: "UCSF A1"));
+      }
+    }
+
+    if (faceShieldUCSFC1 > 0) {
+      if (edit) {
+        list.add(InventoryEditCard(asset: "assets/images/face_shield_card.png",
+            itemName: "Face Shield", quantity: faceShieldUCSFC1, itemType: "UCSF C1", controller: faceShieldController2));
+      } else {
+        list.add(InventoryCard(asset: "assets/images/face_shield_card.png",
+            itemName: "Face Shield", quantity: faceShieldUCSFC1, itemType: "UCSF C1"));
+      }
+    }
+
+    if (maskCloth > 0) {
+      if (edit) {
+        list.add(InventoryEditCard(asset: "assets/images/n95_card.png",
+            itemName: "Mask", quantity: maskCloth, itemType: "Cloth", controller: maskController1));
+      } else {
+        list.add(InventoryCard(asset: "assets/images/n95_card.png",
+            itemName: "Mask", quantity: maskCloth, itemType: "Cloth"));
+      }
+    }
+
+    if (maskN95 > 0) {
+      if (edit) {
+        list.add(InventoryEditCard(asset: "assets/images/n95_card.png",
+            itemName: "Mask", quantity: maskN95, itemType: "N95", controller: maskController2));
+      } else {
+        list.add(InventoryCard(asset: "assets/images/n95_card.png",
+            itemName: "Mask", quantity: maskN95, itemType: "N95"));
+      }
+    }
+
+    if (maskSurgical > 0) {
+      if (edit) {
+        list.add(InventoryEditCard(asset: "assets/images/n95_card.png",
+            itemName: "Mask", quantity: maskSurgical, itemType: "Surgical", controller: maskController3));
+      } else {
+        list.add(InventoryCard(asset: "assets/images/n95_card.png",
+            itemName: "Mask", quantity: maskSurgical, itemType: "Surgical"));
+      }
+    }
+
+    if (glovesSurgical > 0) {
+      if (edit) {
+        list.add(InventoryEditCard(asset: "assets/images/gloves_card.png",
+            itemName: "Gloves", quantity: glovesSurgical, itemType: "Surgical", controller: glovesController1));
+      } else {
+        list.add(InventoryCard(asset: "assets/images/gloves_card.png",
+            itemName: "Gloves", quantity: glovesSurgical, itemType: "Surgical"));
+      }
+    }
+
+    if (glovesNitrile > 0) {
+      if (edit) {
+        list.add(InventoryEditCard(asset: "assets/images/gloves_card.png",
+            itemName: "Gloves", quantity: glovesNitrile, itemType: "Nitrile", controller: glovesController2));
+      } else {
+        list.add(InventoryCard(asset: "assets/images/gloves_card.png",
+            itemName: "Gloves", quantity: glovesNitrile, itemType: "Nitrile"));
+      }
+    }
+
+    if (glovesNeoprene > 0) {
+      if (edit) {
+        list.add(InventoryEditCard(asset: "assets/images/gloves_card.png",
+            itemName: "Gloves", quantity: glovesNeoprene, itemType: "Neoprene", controller: glovesController3));
+      } else {
+        list.add(InventoryCard(asset: "assets/images/gloves_card.png",
+            itemName: "Gloves", quantity: glovesNeoprene, itemType: "Neoprene"));
+      }
+    }
+
+    if (gogglesSurgical > 0) {
+      if (edit) {
+        list.add(InventoryEditCard(asset: "assets/images/goggles_card.png",
+            itemName: "Goggles", quantity: gogglesSurgical, itemType: "Surgical", controller: gogglesController));
+      } else {
+        list.add(InventoryCard(asset: "assets/images/goggles_card.png",
+            itemName: "Goggles", quantity: gogglesSurgical, itemType: "Surgical"));
+      }
+    }
+
+    if (gown > 0) {
+      if (edit) {
+        list.add(InventoryEditCard(asset: "assets/images/gown_card.png",
+            itemName: "Gown", quantity: gown, itemType: "Regular", controller: gownController));
+      } else {
+        list.add(InventoryCard(asset: "assets/images/gown_card.png",
+            itemName: "Gown", quantity: gown, itemType: "Regular"));
+      }
+    }
+
+    if (handSanitizer > 0) {
+      if (edit) {
+        list.add(InventoryEditCard(asset: "assets/images/sanitizer_card.png",
+            itemName: "Hand Sanitizer", quantity: handSanitizer, itemType: "Regular", controller: handSanitizerController));
+      } else {
+        list.add(InventoryCard(asset: "assets/images/sanitizer_card.png",
+            itemName: "Hand Sanitizer", quantity: handSanitizer, itemType: "Regular"));
+      }
+    }
+
+    return new Column(children: list);
+  }
+
+  void updateInventory() async {
+    _firestoreUsers.setHubInventory(widget.user.id, "Gown", "Regular", gownController.text == "" ? gown : int.parse(gownController.text));
+    _firestoreUsers.setHubInventory(widget.user.id, "Face Shield", "UCSF A1", faceShieldController1.text == "" ? faceShieldUCSFA1 : int.parse(faceShieldController1.text));
+    _firestoreUsers.setHubInventory(widget.user.id, "Face Shield", "UCSF C1", faceShieldController2.text == "" ? faceShieldUCSFC1 : int.parse(faceShieldController2.text));
+    _firestoreUsers.setHubInventory(widget.user.id, "Mask", "Cloth", maskController1.text == "" ? maskCloth : int.parse(maskController1.text));
+    _firestoreUsers.setHubInventory(widget.user.id, "Mask", "N95", maskController2.text == "" ? maskN95 : int.parse(maskController2.text));
+    _firestoreUsers.setHubInventory(widget.user.id, "Mask", "Surgical", maskController3.text == "" ? maskSurgical : int.parse(maskController3.text));
+    _firestoreUsers.setHubInventory(widget.user.id, "Gloves", "Surgical", glovesController1.text == "" ? glovesSurgical : int.parse(glovesController1.text));
+    _firestoreUsers.setHubInventory(widget.user.id, "Gloves", "Nitrile", glovesController2.text == "" ? glovesNitrile : int.parse(glovesController2.text));
+    _firestoreUsers.setHubInventory(widget.user.id, "Gloves", "Neoprene", glovesController3.text == "" ? glovesNeoprene : int.parse(glovesController3.text));
+    _firestoreUsers.setHubInventory(widget.user.id, "Goggles", "Surgical", gogglesController.text == "" ? gogglesSurgical : int.parse(gogglesController.text));
+    _firestoreUsers.setHubInventory(widget.user.id, "Hand Sanitizer", "Regular", handSanitizerController.text == "" ? handSanitizer : int.parse(handSanitizerController.text));
+  }
+
+  Widget build(BuildContext context) {
+    return new Padding (
+      padding: EdgeInsets.only(top: 10.0, bottom: 20.0),
+      child: Container(
+        width: MediaQuery.of(context).size.width - 100,
+        child: new Column (
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget> [
+            new Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: <Widget>[
+                  new IconButton(
+                    onPressed: _onInventoryEditButtonPressed,
+                    icon: Image.asset("assets/images/edit_button.png", height: 26, alignment: Alignment.centerRight),
+                  )
+                ]
+            ),
+            if (!_inventoryEditButtonPressed) showInventoryCards(false),
+            if (_inventoryEditButtonPressed) showInventoryCards(true),
+            if (_inventoryEditButtonPressed) new Row (
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                new Padding (
+                  padding: EdgeInsets.only(right: 4),
+                  child: new Container(
+                      width: (MediaQuery.of(context).size.width - 120) * 0.5,
+                      child: new FlatButton(
+                        child: new Text("Save",
+                          style: TextStyle(color: Color(0xFF283568), fontSize: 20, fontFamily: 'Roboto', fontWeight: FontWeight.bold, decoration: TextDecoration.underline),
+                          textAlign: TextAlign.center,),
+                        onPressed: () {
+                          updateInventory();
+                          clearControllers();
+                          _inventoryEditButtonPressed = false;
+                          build(context);
+                        },
+                      )
+                  ),
+                ),
+                new Container(
+                    width: (MediaQuery.of(context).size.width - 120) * 0.5,
+                    child: new FlatButton(
+                      child: new Text("Cancel",
+                        style: TextStyle(color: Color(0xFFD48032), fontSize: 20, fontFamily: 'Roboto', fontWeight: FontWeight.bold, decoration: TextDecoration.underline),
+                        textAlign: TextAlign.center,),
+                      onPressed: () {
+                        _inventoryEditButtonPressed = false;
+                        build(context);
+                      },
+                    )
+                  ),
+                ]
+              )
+            ]
+          )
+      ),
+    );
+  }
+}

--- a/lib/util/firestore_users.dart
+++ b/lib/util/firestore_users.dart
@@ -34,6 +34,15 @@ class FirestoreUsers {
     }
   }
 
+  Future getCollectionHub(String id) async {
+    try {
+      var userData = await _usersCollectionReference.document(id).get();
+      return CollectionHub.fromData(userData.data);
+    } catch (e) {
+      return null;
+    }
+  }
+
   Future updateUserType(String id, String type) async {
     try {
       await _usersCollectionReference.document(id).updateData({"type": type});
@@ -92,6 +101,14 @@ class FirestoreUsers {
     try {
       await _usersCollectionReference.document(id).updateData({"address": address});
       print('Saved address: $address');
+    } catch (e) {
+      return e.message;
+    }
+  }
+
+  Future setHubInventory(String id, String itemName, String itemType, int quantity) async {
+    try {
+      await _usersCollectionReference.document(id).updateData({itemName + "." + itemType: quantity});
     } catch (e) {
       return e.message;
     }

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -425,8 +425,9 @@ class InventoryEditCard extends StatelessWidget {
   final String itemName;
   final int quantity;
   final String itemType;
+  final TextEditingController controller;
 
-  InventoryEditCard({Key key, @required this.asset, @required this.itemName, @required this.quantity, @required this.itemType}) : super(key: key);
+  InventoryEditCard({Key key, @required this.asset, @required this.itemName, @required this.quantity, @required this.itemType, @required this.controller}) : super(key: key);
   @override
   Widget build(BuildContext context) {
     return new Row(
@@ -442,10 +443,29 @@ class InventoryEditCard extends StatelessWidget {
                     textAlign: TextAlign.left,),
                   new Container(
                       width: MediaQuery.of(context).size.width * 0.5,
-                      child: new EditFormField(
-                        type: TextInputType.number,
-                        hint: quantity.toString(),
-                        maxLines: 1,
+                      child: new Container(
+                        width: MediaQuery.of(context).size.width * 0.5,
+                        child: new TextField(
+                          style: TextStyle(color: Colors.black),
+                          textAlign: TextAlign.left,
+                          maxLines: 1,
+                          autofocus: false,
+                          decoration: new InputDecoration(
+                              hintText: quantity.toString(),
+                              hintStyle: TextStyle(fontSize: 15.0, color: Colors.grey),
+                              enabledBorder: new UnderlineInputBorder(
+                                  borderSide: new BorderSide(color: Colors.black)
+                              ),
+                              focusedBorder: new UnderlineInputBorder(
+                                  borderSide: new BorderSide(color: Colors.black)
+                              )
+                          ),
+                          keyboardType: TextInputType.number,
+                          inputFormatters: <TextInputFormatter>[
+                            WhitelistingTextInputFormatter.digitsOnly
+                          ],
+                          controller: controller,
+                        ),
                       )
                   ),
                   SizedBox(height: 10),


### PR DESCRIPTION
**TIPS FOR TESTING THIS PART**: Most Collection Hub accounts won't have any inventory, which means that there are no inventory fields in Firebase for that user either. This makes it difficult to test since nothing displays in the inventory page, so first you can first add to inventory from the Incoming Orders page (press add button). After the first write, all inventory fields will be populated in Firebase. From there, you can manipulate values in Firebase to display more items. 

Overview: Implement inventory backend; includes 'add to inventory' feature (orders page) + inventory tab (profile page)

Screenshots:
<img width="312" alt="Screen Shot 2020-06-23 at 8 25 39 PM" src="https://user-images.githubusercontent.com/24421284/85495732-f1ce4780-b58f-11ea-8459-e3b16152c635.png">
<img width="311" alt="Screen Shot 2020-06-23 at 8 26 08 PM" src="https://user-images.githubusercontent.com/24421284/85495740-f561ce80-b58f-11ea-9cc9-f60ec00eb2b5.png">
<img width="313" alt="Screen Shot 2020-06-23 at 8 28 02 PM" src="https://user-images.githubusercontent.com/24421284/85495788-0b6f8f00-b590-11ea-85f1-8c6ac886d7c6.png">
<img width="311" alt="Screen Shot 2020-06-23 at 8 32 34 PM" src="https://user-images.githubusercontent.com/24421284/85496161-bc762980-b590-11ea-9103-9752a37ae16d.png">

Edited screens:
hub_screen.dart: connect Add To Inventory feature on orders page (incoming) to backend, connect inventory tab to backend
**NOTE: a to-do is to delete incoming orders cards after done adding to inventory, but since orders back-end isn't done, the card will just remain

Edited files:
state_widget.dart: added InventoryPage widget

Edited util:
firestore_users.dart: added more API to connect inventory edits to firebase

Edited data model:
user.dart: added CollectionHub class and related methods